### PR TITLE
Removed group block that was creating unnecessary padding

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -2,8 +2,7 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
-	<!-- wp:group {"layout":{"inherit":true}} -->
-	<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
+	<!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
 
 	<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 
@@ -21,8 +20,7 @@
 
 	<!-- wp:spacer {"height":112} -->
 	<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer --></div>
-	<!-- /wp:group -->
+	<!-- /wp:spacer -->
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,8 +2,7 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
+<!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 
@@ -21,8 +20,7 @@
 
 <!-- wp:spacer {"height":112} -->
 <div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
-<!-- /wp:group -->
+<!-- /wp:spacer -->
 <!-- /wp:post-template -->
 
 <!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->


### PR DESCRIPTION
Fixes: https://github.com/WordPress/twentytwentythree/issues/2

This change removes the `wp:group` block from the `wp:query` block eliminating the duplicate gap.

Before:
<img width="396" alt="image" src="https://user-images.githubusercontent.com/146530/183941773-257198bc-c5f5-4e84-8e34-4da7cd672cbf.png">

After:
<img width="477" alt="image" src="https://user-images.githubusercontent.com/146530/183941652-d8abc7d7-4669-434a-bb57-b0b334b3e289.png">
