### PR TITLE
Moved primary color for links to post-content

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -191,6 +191,15 @@
 					}
 				}
 			},
+			"core/post-content": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--secondary)"
+						}
+					}
+				}
+			},
 			"core/post-comments": {
 				"spacing": {
 					"padding": {
@@ -326,7 +335,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--secondary)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				":hover": {
 					"typography": {


### PR DESCRIPTION
Fixes (part of) #4 

This change sets default link color to `foreground` and color for links in `post-content` to `primary`.

Before:
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/146530/184020833-a576604a-6868-48b9-9fc1-f692523677e8.png">

After:
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/146530/184020623-b9aa314c-8ce7-467a-8201-5452891131c9.png">
