### PR TITLE
Remove site logo and wrapping row

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -1,11 +1,7 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--90)","top":"var(--wp--preset--spacing--50)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--90)"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
-
-<!-- wp:site-title /--></div>
-<!-- /wp:group -->
-
+<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--90)">
+<!-- wp:site-title /-->
 <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Removes the site logo. Closes https://github.com/WordPress/twentytwentythree/issues/7.

Also removes the group block that was only used to group the logo and title together to place them both to the left of the menu, because it is no longer needed.