### PR TITLE
Remove opinion from templates

### DIFF
--- a/patterns/footer-default.php
+++ b/patterns/footer-default.php
@@ -7,8 +7,8 @@
  */
 ?>
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--90)"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--90)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title {"level":0} /-->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--90)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--90)","bottom":"var(--wp--preset--spacing--90)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--90);padding-bottom:var(--wp--preset--spacing--90)"><!-- wp:site-title {"level":0} /-->
 
 <!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right"><?php

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -5,8 +5,8 @@
  * Inserter: no
  */
 ?>
-<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(4rem, 40vw, 20rem)","fontWeight":"200","lineHeight":"1"}},"className":"has-text-align-center"} -->
-<h2 class="has-text-align-center" style="font-size:clamp(4rem, 40vw, 20rem);font-weight:200;line-height:1"><?php esc_html( _x( '404', 'Error code for a webpage that is not found.', 'twentytwentythree' ) ) ?></h2>
+<!-- wp:heading {"className":"has-text-align-center"} -->
+<h2 class="has-text-align-center"><?php esc_html( _x( '404', 'Error code for a webpage that is not found.', 'twentytwentythree' ) ) ?></h2>
 <!-- /wp:heading -->
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php esc_html__( 'This page could not be found. Maybe try a search?', 'twentytwentythree' ) ?></p>

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,19 +1,19 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:query-title {"type":"archive","align":"wide","style":{"typography":{"fontSize":"clamp(2.75rem, 6vw, 3.25rem)"},"spacing":{"margin":{"bottom":"6rem"}}}} /-->
+<div class="wp-block-group"><!-- wp:query-title {"type":"archive","align":"wide"} /-->
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","align":"wide","layout":{"inherit":false}} -->
 <main class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-<!-- wp:post-title {"isLink":true,"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"x-large"} /-->
+<!-- wp:post-title {"isLink":true,"align":"wide"} /-->
 
-<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
+<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"650px"} -->
 <div class="wp-block-column" style="flex-basis:650px"><!-- wp:post-excerpt /-->
 
-<!-- wp:post-date {"format":"F j, Y","isLink":true,"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
+<!-- wp:post-date {"format":"F j, Y","isLink":true} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":""} -->
@@ -27,8 +27,8 @@
 <!-- /wp:post-template -->
 
 <!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-<!-- wp:query-pagination-previous {"fontSize":"small"} /-->
-<!-- wp:query-pagination-next {"fontSize":"small"} /-->
+<!-- wp:query-pagination-previous /-->
+<!-- wp:query-pagination-next /-->
 <!-- /wp:query-pagination --></main>
 <!-- /wp:query --></div>
 <!-- /wp:group -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,15 +2,15 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
-	<!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
+	<!-- wp:post-title {"isLink":true,"align":"wide"} /-->
 
-	<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
+	<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 
 	<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column {"width":"650px"} -->
 	<div class="wp-block-column" style="flex-basis:650px"><!-- wp:post-excerpt /-->
 
-	<!-- wp:post-date {"isLink":true,"format":"F j, Y","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
+	<!-- wp:post-date {"isLink":true,"format":"F j, Y"} /--></div>
 	<!-- /wp:column -->
 
 	<!-- wp:column {"width":""} -->
@@ -24,11 +24,11 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<!-- wp:query-pagination-previous {"fontSize":"small"} /-->
+	<!-- wp:query-pagination-previous /-->
 
 	<!-- wp:query-pagination-numbers /-->
 
-	<!-- wp:query-pagination-next {"fontSize":"small"} /-->
+	<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination --></main>
 	<!-- /wp:query -->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,15 +2,15 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
-<!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
+<!-- wp:post-title {"isLink":true,"align":"wide"} /-->
 
-<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
+<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"650px"} -->
 <div class="wp-block-column" style="flex-basis:650px"><!-- wp:post-excerpt /-->
 
-<!-- wp:post-date {"isLink":true,"format":"F j, Y","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
+<!-- wp:post-date {"isLink":true,"format":"F j, Y"} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":""} -->
@@ -24,8 +24,8 @@
 <!-- /wp:post-template -->
 
 <!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-<!-- wp:query-pagination-previous {"fontSize":"small"} /-->
-<!-- wp:query-pagination-next {"fontSize":"small"} /-->
+<!-- wp:query-pagination-previous /-->
+<!-- wp:query-pagination-next /-->
 <!-- /wp:query-pagination --></main>
 <!-- /wp:query -->
 

--- a/templates/page-no-separators.html
+++ b/templates/page-no-separators.html
@@ -2,16 +2,16 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} /-->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide"} /-->
 
-<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} /--></div>
+<!-- wp:post-featured-image {"align":"wide"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-<!-- wp:post-comments {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--70)"}}}} /--></div>
+<!-- wp:post-comments /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,9 +2,9 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} /-->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide"} /-->
 
-<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} /-->
+<!-- wp:post-featured-image {"align":"wide"} /-->
 
 <!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
 <hr class="wp-block-separator alignwide is-style-wide"/>
@@ -19,7 +19,7 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-<!-- wp:post-comments {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--70)"}}}} /--></div>
+<!-- wp:post-comments /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,21 +1,21 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--90)"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--90)"><!-- wp:search {"label":"Search","showLabel":false,"width":100,"widthUnit":"%","buttonText":"Search","buttonUseIcon":true} /--></div>
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:search {"label":"Search","showLabel":false,"width":100,"widthUnit":"%","buttonText":"Search","buttonUseIcon":true} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide"} /-->
 
-<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
+<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"650px"} -->
 <div class="wp-block-column" style="flex-basis:650px"><!-- wp:post-excerpt /-->
 
-<!-- wp:post-date {"isLink":true,"format":"F j, Y","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
+<!-- wp:post-date {"isLink":true,"format":"F j, Y"} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":""} -->
@@ -30,8 +30,8 @@
 <!-- /wp:post-template -->
 
 <!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-<!-- wp:query-pagination-previous {"fontSize":"small"} /-->
-<!-- wp:query-pagination-next {"fontSize":"small"} /-->
+<!-- wp:query-pagination-previous /-->
+<!-- wp:query-pagination-next /-->
 <!-- /wp:query-pagination --></main>
 <!-- /wp:query -->
 

--- a/templates/single-no-separators.html
+++ b/templates/single-no-separators.html
@@ -2,9 +2,9 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} /-->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide"} /-->
 
-<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} /--></div>
+<!-- wp:post-featured-image {"align":"wide"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
@@ -15,13 +15,13 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"format":"F j, Y","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /-->
+<div class="wp-block-group"><!-- wp:post-date {"format":"F j, Y"} /-->
 
-<!-- wp:post-author {"showAvatar":false,"fontSize":"small"} /-->
+<!-- wp:post-author {"showAvatar":false} /-->
 
-<!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
+<!-- wp:post-terms {"term":"category"} /-->
 
-<!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
+<!-- wp:post-terms {"term":"post_tag"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:spacer {"height":32} -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -2,9 +2,9 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} /-->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide"} /-->
 
-<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} /-->
+<!-- wp:post-featured-image {"align":"wide"} /-->
 
 <!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
 <hr class="wp-block-separator alignwide is-style-wide"/>
@@ -23,13 +23,13 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"format":"F j, Y","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /-->
+<div class="wp-block-group"><!-- wp:post-date {"format":"F j, Y"} /-->
 
-<!-- wp:post-author {"showAvatar":false,"fontSize":"small"} /-->
+<!-- wp:post-author {"showAvatar":false} /-->
 
-<!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
+<!-- wp:post-terms {"term":"category"} /-->
 
-<!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
+<!-- wp:post-terms {"term":"post_tag"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:spacer {"height":32} -->

--- a/theme.json
+++ b/theme.json
@@ -191,6 +191,12 @@
 					}
 				}
 			},
+			"core/post-author": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontStyle": "italic"
+				}
+			},
 			"core/post-content": {
 				"elements": {
 					"link": {
@@ -207,10 +213,22 @@
 					}
 				}
 			},
+			"core/post-date": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontStyle": "italic"
+				}
+			},
+			"core/post-terms": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontStyle": "italic"
+				}
+			},
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system-font)",
-					"fontSize": "clamp(3.25rem, calc(3.25rem + ((1vw - 0.48rem) * 8.4135)), 3.625rem)",
+					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontWeight": "300",
 					"lineHeight": "1.2"
 				}
@@ -218,6 +236,11 @@
 			"core/pullquote": {
 				"border": {
 					"width": "1px 0"
+				}
+			},
+			"core/query-pagination": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/query-title": {

--- a/theme.json
+++ b/theme.json
@@ -91,6 +91,7 @@
 		},
 		"typography": {
 			"dropCap": false,
+			"fluid": true,
 			"fontFamilies": [
 				{
 					"fontFace": [
@@ -163,11 +164,11 @@
 				},
 				{
 					"size": "2.25rem",
-					"fluid": {
-						"max": "2.25rem",
-						"min": "2rem"
-					},
 					"slug": "x-large"
+				},
+				{
+					"size": "2.75rem",
+					"slug": "xx-large"
 				}
 			]
 		},
@@ -228,7 +229,7 @@
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system-font)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "300",
 					"lineHeight": "1.2"
 				}


### PR DESCRIPTION
There are quite a lot of styles in the templates which I think can be achieved in theme.json. If we remove these then it gives us a greater range of style options we can achieve using theme.json.

Where it makes sense I have added the opinion to theme.json.