### PR TITLE
Change PHP minimum version to 5.6

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org
 Description:
 Requires at least: 5.9
 Tested up to: 6.1
-Requires PHP: 7.4
+Requires PHP: 5.6
 Version: 0.0.1
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
WordPress 6.1 has the minimium PHP version 5.6, so you should be able to install the theme with this version.

It was changed in #18.