### PR TITLE
Update readme to include more information about style variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you'd like to help with triage, let @mikachan and @beafialho know here or in 
 
 ### Contributing Style Variations
 
-A big part of Twenty Twenty-Three is to emphasize a diverse collection of style variations, so this is a great way to contribute to the theme!
+A big part of Twenty Twenty-Three is to emphasize a diverse collection of style variations, so this is a great way to contribute to the theme! You can read more about this in the [project kick-off post](https://make.wordpress.org/design/2022/08/10/twenty-twenty-three-default-theme-project-kickoff/).
 
 #### Design a style variation
 This can be done a few different ways, including:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the development repository for the default theme that will launch wit
 
 ## About
 
-Twenty Twenty-Three is a stripped-back and minimal version of Twenty Twenty-Two, and will include a diverse collection of style variations designed by members of the community.
+Twenty Twenty-Three is a stripped-back and minimal version of [Twenty Twenty-Two](https://wordpress.org/themes/twentytwentytwo/), and will include a diverse collection of style variations designed by members of the community.
 
 ## Contributing
 
@@ -12,7 +12,25 @@ If you would like to contribute code, the list of [open issues](https://github.c
 
 Contributing is not just for developers! There are many opportunities to help with [testing](#getting-started), triage, discussion, designing and building variations, and more. Please look through [open issues](https://github.com/WordPress/twentytwentythree/issues), and join in wherever you feel most comfortable.
 
-If you'd like to help with triage, let @mikachan and @beafialho know here or in [WordPress.org's Slack instance](https://make.wordpress.org/chat/). We'll help you get set up with the ability to add labels to issues and PRs.
+If you'd like to help with triage, let @mikachan and @beafialho know here or in [WordPress.org's Slack instance](https://make.wordpress.org/chat/). The #core-themes-projects channel is a good place to start. We'll help you get set up with the ability to add labels to issues and PRs.
+
+### Contributing Style Variations
+
+A big part of Twenty Twenty-Three is to emphasize a diverse collection of style variations, so this is a great way to contribute to the theme!
+
+#### Design a style variation
+This can be done a few different ways, including:
+
+- Create an alternate theme.json file to the one provided by the theme and change values directly in the code.
+- Make changes in the Global Styles panel in the Site Editor. You can save these changes as a new style variation using the [Create Block Theme plugin](https://wordpress.org/plugins/create-block-theme/).
+- Design static mockups in Figma or a similar program.
+
+#### Submit your style variation
+When you're ready to submit, please create a new issue and share your designs:
+
+- Theme.json files can be submitted as code or as zip files. 
+- Add images that showcase the look & feel of the variation.
+- Include a style guide with design specifications — this should include details on typography, colors, spacing, etc. Here’s an [example](https://www.figma.com/community/file/1136340417938880987).
 
 ### Getting Started
 
@@ -40,7 +58,8 @@ Some theme features / PRs may require Gutenberg trunk and will be described or t
 
 ## Resources
 
-- [Twenty Twenty-Three Figma Mockups](https://www.figma.com/file/ohYEHkZzGjOse46NceTfj5/Twenty-Twenty-Three)
+- [Twenty Twenty-Three Figma Mockups](https://www.figma.com/community/file/1139275543113752375)
+- [Twenty Twenty-Three Project kickoff post](https://make.wordpress.org/design/2022/08/10/twenty-twenty-three-default-theme-project-kickoff/)
 - [Setting up a development environment](https://developer.wordpress.org/block-editor/handbook/tutorials/devenv/)
 - [Create Block Theme plugin](https://github.com/WordPress/create-block-theme)
 - [Block Theme documentation](https://developer.wordpress.org/block-editor/how-to-guides/themes/block-theme-overview)


### PR DESCRIPTION
This PR updates the main readme file to include information about designing and submitting style variations, taken from the [project kick-off post](https://make.wordpress.org/design/2022/08/10/twenty-twenty-three-default-theme-project-kickoff/).

I've also added a link to the project kick-off post, and fixed the link to the Figma mockups (which fixes https://github.com/WordPress/twentytwentythree/issues/15).

