### PR TITLE
Clean base theme theme.json file

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -301,29 +301,23 @@
 			"h2": {
 				"typography": {
 					"fontSize": "clamp(2.625rem, calc(2.625rem + ((1vw - 0.48rem) * 8.4135)), 3.25rem)",
-					"fontWeight": "300",
 					"lineHeight": "1.2"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "2.25rem",
-					"fontWeight": "300",
-					"lineHeight": "1.4"
+					"fontSize": "2.25rem"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "clamp(1.75rem, calc(1.75rem + ((1vw - 0.48rem) * 8.4135)), 1.875em)",
-					"fontWeight": "300",
-					"lineHeight": "1.4"
+					"fontSize": "clamp(1.75rem, calc(1.75rem + ((1vw - 0.48rem) * 8.4135)), 1.875em)"
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "700",
-					"lineHeight": "1.4",
 					"textTransform": "uppercase"
 				}
 			},
@@ -331,13 +325,14 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "400",
-					"lineHeight": "1.4",
 					"textTransform": "uppercase"
 				}
 			},
 			"heading": {
 				"typography": {
-					"letterSpacing": "-0.02rem"
+					"fontWeight": "300",
+					"letterSpacing": "-0.02rem",
+					"lineHeight": "1.4"
 				}
 			},
 			"link": {

--- a/theme.json
+++ b/theme.json
@@ -237,13 +237,6 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
-			"core/query-title": {
-				"typography": {
-					"fontSize": "clamp(3.25rem, calc(3.25rem + ((1vw - 0.48rem) * 8.4135)), 3.625rem)",
-					"fontWeight": "300",
-					"lineHeight": "1.2"
-				}
-			},
 			"core/quote": {
 				"border": {
 					"width": "1px"

--- a/theme.json
+++ b/theme.json
@@ -224,9 +224,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "300",
-					"lineHeight": "1.2"
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
 				}
 			},
 			"core/pullquote": {

--- a/theme.json
+++ b/theme.json
@@ -9,13 +9,6 @@
 			"title": "Blank"
 		},
 		{
-			"name": "page-large-header",
-			"postTypes": [
-				"page"
-			],
-			"title": "Page (Large Header)"
-		},
-		{
 			"name": "single-no-separators",
 			"postTypes": [
 				"post"

--- a/theme.json
+++ b/theme.json
@@ -183,6 +183,9 @@
 							}
 						}
 					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/post-author": {

--- a/theme.json
+++ b/theme.json
@@ -221,7 +221,6 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "300",
 					"lineHeight": "1.2"
@@ -239,7 +238,6 @@
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "clamp(3.25rem, calc(3.25rem + ((1vw - 0.48rem) * 8.4135)), 3.625rem)",
 					"fontWeight": "300",
 					"lineHeight": "1.2"
@@ -252,7 +250,6 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontStyle": "italic",
 					"fontWeight": "normal",
@@ -297,15 +294,12 @@
 			},
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "3.625rem",
-					"fontWeight": "300",
 					"lineHeight": "1.2"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "clamp(2.625rem, calc(2.625rem + ((1vw - 0.48rem) * 8.4135)), 3.25rem)",
 					"fontWeight": "300",
 					"lineHeight": "1.2"
@@ -313,7 +307,6 @@
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "2.25rem",
 					"fontWeight": "300",
 					"lineHeight": "1.4"
@@ -321,7 +314,6 @@
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "clamp(1.75rem, calc(1.75rem + ((1vw - 0.48rem) * 8.4135)), 1.875em)",
 					"fontWeight": "300",
 					"lineHeight": "1.4"
@@ -329,7 +321,6 @@
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "700",
 					"lineHeight": "1.4",
@@ -338,7 +329,6 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "400",
 					"lineHeight": "1.4",


### PR DESCRIPTION
This PR cleans up the base theme.json file.

- Removed a reference to a template that doesn't exist (page large header)
- Removed multiple references to the global font family, as they're unnecessary 
- Moved repeated settings from individual headings to the heading element
- Set the navigation font size to `small`