### PR TITLE
Try a simpler home template

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -2,23 +2,17 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
-	<!-- wp:post-title {"isLink":true,"align":"wide"} /-->
+	<!-- wp:group {"layout":{"inherit":true}} --><div class="wp-block-group">
+	<!-- wp:post-title {"isLink":true} /-->
 
 	<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 
-	<!-- wp:columns {"align":"wide"} -->
-	<div class="wp-block-columns alignwide"><!-- wp:column {"width":"650px"} -->
-	<div class="wp-block-column" style="flex-basis:650px"><!-- wp:post-excerpt /-->
+	<!-- wp:post-excerpt /-->
 
-	<!-- wp:post-date {"isLink":true,"format":"F j, Y"} /--></div>
-	<!-- /wp:column -->
+	<!-- wp:post-date {"format":"F j, Y","isLink":true} /--></div>
+	<!-- /wp:group -->
 
-	<!-- wp:column {"width":""} -->
-	<div class="wp-block-column"></div>
-	<!-- /wp:column --></div>
-	<!-- /wp:columns -->
-
-	<!-- wp:spacer {"height":112} -->
+	<!-- wp:spacer {"height":"112px"} -->
 	<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 	<!-- /wp:post-template -->


### PR DESCRIPTION
The home template contains a 650px wide column, which is a setting from theme.json. This PR tries to remove that static width and instead replace it with inheriting the default layout. The downside is that now the content is no longer offset:

Before:
<img width="1440" alt="Screenshot 2022-08-12 at 14 40 09" src="https://user-images.githubusercontent.com/275961/184365659-229296ea-0113-480a-8ac3-abba53619189.png">
<img width="1440" alt="Screenshot 2022-08-12 at 14 41 34" src="https://user-images.githubusercontent.com/275961/184365997-5b316bfa-cbfb-4d75-b85f-d3a6b9c86b34.png">


After:
<img width="1440" alt="Screenshot 2022-08-12 at 14 39 34" src="https://user-images.githubusercontent.com/275961/184365574-0771781a-062f-47c3-ba03-b6c38d7b5144.png">

<img width="1439" alt="Screenshot 2022-08-12 at 14 41 47" src="https://user-images.githubusercontent.com/275961/184365958-a192bbf5-4d68-4f66-8d41-8d243e917d81.png">

I'm not sure if this is an improvement or not.

