### PR TITLE
Move JSON schema and version prop to top

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"customTemplates": [
 		{
 			"name": "blank",
@@ -371,7 +373,5 @@
 			"name": "footer",
 			"title": "Footer"
 		}
-	],
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	]
 }


### PR DESCRIPTION
Move `version` and `$schema` to the top of `theme.json` file. 

Reasons:
- The version property should be visible as soon as someone opens the theme.json
- After getting many references, I found that defining `$schema` at the file top make much more sense. Ref: https://json-schema.org/learn/getting-started-step-by-step.html