### PR TITLE
Add the home page "call to action" / signup pattern

### DIFF
--- a/patterns/call-to-action.php
+++ b/patterns/call-to-action.php
@@ -9,17 +9,16 @@
 ?>
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide">
-	<!-- wp:column {"width":"40%"} -->
-	<div class="wp-block-column" style="flex-basis:40%">
-		<!-- wp:paragraph {"fontSize":"x-large"} -->
-		<p class="has-x-large-font-size">
-		<?php esc_html_e( 'Get daily reflections in your inbox.', 'twentytwentythree' ); ?>
-		</p><!-- /wp:paragraph -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large"} -->
+		<p class="has-x-large-font-size" style="line-height:1.2">Got any book recommendations?</p>
+		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons -->
 		<div class="wp-block-buttons"><!-- wp:button {"fontSize":"small"} -->
 		<div class="wp-block-button has-custom-font-size has-small-font-size"><a class="wp-block-button__link wp-element-button">
-			<?php esc_html_e( 'Join our mailing list', 'twentytwentythree' ); ?>
+			<?php esc_html_e( 'Get In Touch', 'twentytwentythree' ); ?>
 		</a></div>
 		<!-- /wp:button --></div>
 		<!-- /wp:buttons --></div>

--- a/patterns/call-to-action.php
+++ b/patterns/call-to-action.php
@@ -3,7 +3,7 @@
  * Title: Call to action
  * Slug: twentytwentythree/cta
  * Categories: featured
- * Keywords: Call to action, signup, newsletter
+ * Keywords: Call to action
  * Block Types: core/buttons
  */
 ?>
@@ -12,7 +12,9 @@
 	<!-- wp:column -->
 	<div class="wp-block-column">
 		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large"} -->
-		<p class="has-x-large-font-size" style="line-height:1.2">Got any book recommendations?</p>
+		<p class="has-x-large-font-size" style="line-height:1.2">
+		<?php esc_html_e( 'Got any book recommendations?', 'twentytwentythree' ); ?>
+		</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons -->

--- a/patterns/call-to-action.php
+++ b/patterns/call-to-action.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Title: Call to action
+ * Slug: twentytwentythree/cta
+ * Categories: featured
+ * Keywords: Call to action, signup, newsletter
+ * Block Types: core/buttons
+ */
+?>
+<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide">
+	<!-- wp:column {"width":"40%"} -->
+	<div class="wp-block-column" style="flex-basis:40%">
+		<!-- wp:paragraph {"fontSize":"x-large"} -->
+		<p class="has-x-large-font-size">
+		<?php esc_html_e( 'Get daily reflections in your inbox.', 'twentytwentythree' ); ?>
+		</p><!-- /wp:paragraph -->
+
+		<!-- wp:buttons -->
+		<div class="wp-block-buttons"><!-- wp:button {"fontSize":"small"} -->
+		<div class="wp-block-button has-custom-font-size has-small-font-size"><a class="wp-block-button__link wp-element-button">
+			<?php esc_html_e( 'Join our mailing list', 'twentytwentythree' ); ?>
+		</a></div>
+		<!-- /wp:button --></div>
+		<!-- /wp:buttons --></div>
+	<!-- /wp:column -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:separator -->
+		<hr class="wp-block-separator has-alpha-channel-opacity"/>
+		<!-- /wp:separator -->
+	</div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->


### PR DESCRIPTION
Adding this pattern here for now, and we can discuss if it should be in the pattern directory or the theme.

I am concerned the text might indicate to some users that the theme has some sort of newsletter functionality.
Can we come up with something more neutral?