### PR TITLE
Fix heading font sizes

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -373,7 +373,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "clamp(1.75rem, calc(1.75rem + ((1vw - 0.48rem) * 8.4135)), 1.875em)"
+					"fontSize": "clamp(1.75rem, calc(1.75rem + ((1vw - 0.48rem) * 8.4135)), 1.875rem)"
 				}
 			},
 			"h5": {


### PR DESCRIPTION
Closes https://github.com/WordPress/twentytwentythree/issues/69

There was a typo on the font size unit for H4, this fixes it.

Before:

<img width="1117" alt="Screenshot 2022-08-17 at 09 45 05" src="https://user-images.githubusercontent.com/3593343/185064821-feef477d-4cc9-4ea0-aa57-9c832efa6b66.png">

After:

<img width="1139" alt="Screenshot 2022-08-17 at 09 51 04" src="https://user-images.githubusercontent.com/3593343/185064808-c2980b9d-cac4-40cd-8d2d-78dead65a003.png">



