### PR TITLE
Replace default link color variable

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -406,7 +406,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"text": "var(--wp--preset--color--contrast)"
 				},
 				":hover": {
 					"typography": {


### PR DESCRIPTION
The default link color variable is currently set to `foreground`, which isn't used in this theme. This PR replaces it with `contrast`.