### PR TITLE
Add minimum value for small and medium sizes

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -219,14 +219,14 @@
 			"fontSizes": [
 				{
 					"fluid": {
-						"min": "14px"
+						"min": "0.875rem"
 					},
 					"size": "1rem",
 					"slug": "small"
 				},
 				{
 					"fluid": {
-						"min": "16px"
+						"min": "1rem"
 					},
 					"size": "1.125rem",
 					"slug": "medium"

--- a/theme.json
+++ b/theme.json
@@ -218,10 +218,16 @@
 			],
 			"fontSizes": [
 				{
+					"fluid": {
+						"min": "14px"
+					},
 					"size": "1rem",
 					"slug": "small"
 				},
 				{
+					"fluid": {
+						"min": "16px"
+					},
 					"size": "1.125rem",
 					"slug": "medium"
 				},


### PR DESCRIPTION
This PR adds a `min` value for the small and medium fluid font sizes, as I believe they are scaling down too much at smaller resolutions.

- Small: was scaling down to `12px`, now fixed at a minimum value of `14px` / `0.875rem`
- Medium: was scaling down to `13.5px`, now fixed at a minimum value of `16px` / `1rem`

Closes https://github.com/WordPress/twentytwentythree/issues/76.