### PR TITLE
Update navigation and site title styles

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -449,13 +449,21 @@
 				},
 				":hover": {
 					"typography": {
-						"textDecoration": "underline dashed"
+						"textDecoration": "none"
 					}
 				},
 				":active": {
 					"typography": {
 						"textDecoration": "none"
 					}
+				},
+				":focus": {
+					"typography": {
+						"textDecoration": "none"
+					}
+				},
+				"typography": {
+					"textDecoration": "underline"
 				}
 			}
 		},

--- a/theme.json
+++ b/theme.json
@@ -312,6 +312,21 @@
 				},
 				"elements": {
 					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":active": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
 						"typography": {
 							"textDecoration": "none"
 						}
@@ -452,12 +467,12 @@
 						"textDecoration": "none"
 					}
 				},
-				":active": {
+				":focus": {
 					"typography": {
 						"textDecoration": "none"
 					}
 				},
-				":focus": {
+				":active": {
 					"typography": {
 						"textDecoration": "none"
 					}

--- a/theme.json
+++ b/theme.json
@@ -342,6 +342,23 @@
 				}
 			},
 			"core/site-title": {
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "normal",

--- a/theme.json
+++ b/theme.json
@@ -290,6 +290,7 @@
 			},
 			"core/post-date": {
 				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": "400"
 				},
 				"elements": {

--- a/theme.json
+++ b/theme.json
@@ -253,7 +253,12 @@
 						},
 						":focus": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"typography": {
+								"textDecoration": "none"
 							}
 						},
 						"typography": {
@@ -323,12 +328,15 @@
 						},
 						":focus": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline dashed"
 							}
 						},
 						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "none"
 							}
 						},
 						"typography": {
@@ -370,7 +378,15 @@
 						},
 						":focus": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
+							"typography": {
+								"textDecoration": "none"
 							}
 						},
 						"typography": {
@@ -473,10 +489,13 @@
 				},
 				":focus": {
 					"typography": {
-						"textDecoration": "none"
+						"textDecoration": "underline dashed"
 					}
 				},
 				":active": {
+					"color": {
+						"text": "var(--wp--preset--color--secondary)"
+					},
 					"typography": {
 						"textDecoration": "none"
 					}

--- a/theme.json
+++ b/theme.json
@@ -243,7 +243,7 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/navigation-link": {
+			"core/navigation": {
 				"elements": {
 					"link": {
 						":hover": {

--- a/theme.json
+++ b/theme.json
@@ -255,6 +255,9 @@
 							"typography": {
 								"textDecoration": "underline"
 							}
+						},
+						"typography": {
+							"textDecoration": "none"
 						}
 					}
 				},


### PR DESCRIPTION
This PR moves the link styles from the child `navigation-link` block to the parent `navigation` block.

It also replicates these link styles on the `site-title` block, so that the site title link states match the navigation link states.

Closes https://github.com/WordPress/twentytwentythree/issues/74.