### PR TITLE
Escaping and translation enhancements for patterns

### DIFF
--- a/patterns/call-to-action.php
+++ b/patterns/call-to-action.php
@@ -13,14 +13,14 @@
 	<div class="wp-block-column">
 		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large"} -->
 		<p class="has-x-large-font-size" style="line-height:1.2">
-		<?php esc_html_e( 'Got any book recommendations?', 'twentytwentythree' ); ?>
+		<?php echo esc_html_x( 'Got any book recommendations?', 'sample content for call to action', 'twentytwentythree' ); ?>
 		</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons -->
 		<div class="wp-block-buttons"><!-- wp:button {"fontSize":"small"} -->
 		<div class="wp-block-button has-custom-font-size has-small-font-size"><a class="wp-block-button__link wp-element-button">
-			<?php esc_html_e( 'Get In Touch', 'twentytwentythree' ); ?>
+			<?php echo esc_html_x( 'Get In Touch', 'sample content for call to action button', 'twentytwentythree' ); ?>
 		</a></div>
 		<!-- /wp:button --></div>
 		<!-- /wp:buttons --></div>

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -7,15 +7,15 @@
 ?>
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"clamp(4rem, 40vw, 20rem)","fontWeight":"400","lineHeight":"1.25"}},"className":"has-text-align-center"} -->
-<h2 class="has-text-align-center" style="font-size:clamp(4rem, 40vw, 20rem);font-weight:400;line-height:1.25"><?php echo esc_html( _x( '404', 'Error code for a webpage that is not found.', 'twentytwentythree' ) ); ?></h2>
+<h2 class="has-text-align-center" style="font-size:clamp(4rem, 40vw, 20rem);font-weight:400;line-height:1.25"><?php echo esc_html_x( '404', 'Error code for a webpage that is not found.', 'twentytwentythree' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center"><?php esc_html_e( 'This page could not be found.', 'twentytwentythree' ); ?></p>
+<p class="has-text-align-center"><?php echo esc_html_x( 'This page could not be found.', 'Message to convey that a webpage could not be found', 'twentytwentythree' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer {"height":"var(--wp--preset--spacing--100)"} -->
 <div style="height:var(--wp--preset--spacing--100)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:search {"label":"<?php echo esc_html( _x( 'Search', 'label', 'twentytwentythree' ) ); ?>","placeholder":"<?php echo esc_html( _x( 'Search...', 'placeholder', 'twentytwentythree' ) ); ?>","showLabel":false,"width":70,"widthUnit":"%","buttonText":"<?php esc_html_e( 'Search', 'twentytwentythree' ); ?>","buttonUseIcon":true,"align":"center"} /-->
+<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'label', 'twentytwentythree' ); ?>","placeholder":"<?php echo esc_html_x( 'Search...', 'placeholder for search field', 'twentytwentythree' ); ?>","showLabel":false,"width":70,"widthUnit":"%","buttonText":"<?php esc_html_e( 'Search', 'twentytwentythree' ); ?>","buttonUseIcon":true,"align":"center"} /-->


### PR DESCRIPTION
Addresses #88

Use proper escaping and translation functions in patterns that also account for context for translators when possible.

Note: no changes were necessary for the current `patterns/footer-default.php`. Therefore, it was not touched.