### PR TITLE
Moved sizing opinions from home to theme.json

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -6,18 +6,18 @@
 	<!-- wp:image {"align":"wide"} -->
 	<figure class="wp-block-image alignwide"><img alt=""/></figure>
 	<!-- /wp:image -->
-	
-	<!-- wp:heading {"align":"wide","style":{"typography":{"fontWeight":"400"},"spacing":{"margin":{"top":"8rem","bottom":"8rem"}}}} -->
-	<h2 class="alignwide" style="margin-top:8rem;margin-bottom:8rem;font-weight:400;">Mindblown: a blog about philosophy.</h2>
+	<!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"8rem","bottom":"8rem"}}}} -->
+	<h2 class="alignwide" style="margin-top:8rem;margin-bottom:8rem;">Mindblown: a blog about philosophy.</h2>
 	<!-- /wp:heading -->
-	
+
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 		<div class="wp-block-group alignwide">
-			<!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
-			<h3 class="has-small-font-size" style="font-style:normal;font-weight:400;text-transform:uppercase">Latests posts</h3>
+			<!-- wp:heading {"level":6} -->
+			<h6>Latests posts</h6>
 			<!-- /wp:heading -->
+
 			<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"right"}} -->
 			<!-- wp:query-pagination-next {"label":"View more"} /-->
 			<!-- /wp:query-pagination -->

--- a/theme.json
+++ b/theme.json
@@ -399,12 +399,14 @@
 			"h2": {
 				"typography": {
 					"fontSize": "clamp(2.625rem, calc(2.625rem + ((1vw - 0.48rem) * 8.4135)), 3.25rem)",
+					"fontWeight": "400",
 					"lineHeight": "1.2"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "2.25rem"
+					"fontSize": "2.25rem",
+					"fontWeight": "400"
 				}
 			},
 			"h4": {


### PR DESCRIPTION
This change increases the font weight of H2 and H3 to 400.  The only places I've noticed it's used is in the home template and both of those instances were increasing the font weight so I suggest we do that in theme.json instead.

The 'Latest Posts' text was an H3 customized to nearly the same values assigned to H6 so i just changed it to an H6.

Before:

<img width="292" alt="image" src="https://user-images.githubusercontent.com/146530/186059075-181a7b3d-c40a-4029-8401-53524c2f1a29.png">

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/146530/186058995-291aae08-d81a-4f05-a081-dc94822837df.png">


After:
<img width="299" alt="image" src="https://user-images.githubusercontent.com/146530/186058834-26095b84-9ded-4668-90f2-0fde7d7870eb.png">

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/146530/186058922-a99f336d-de07-40aa-bdc0-e1d79f729ca1.png">

Partially addresses #84 