### PR TITLE
Add the call to action block pattern to the home template

### DIFF
--- a/patterns/call-to-action.php
+++ b/patterns/call-to-action.php
@@ -12,8 +12,7 @@
 	<!-- wp:column -->
 	<div class="wp-block-column">
 		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large"} -->
-		<p class="has-x-large-font-size" style="line-height:1.2">
-		<?php echo esc_html_x( 'Got any book recommendations?', 'sample content for call to action', 'twentytwentythree' ); ?>
+		<p class="has-x-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'Got any book recommendations?', 'sample content for call to action', 'twentytwentythree' ); ?>
 		</p>
 		<!-- /wp:paragraph -->
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -34,11 +34,10 @@
 		<!-- /wp:post-template -->
 	</div>
 	<!-- /wp:query -->
+
+	<!-- wp:pattern {"slug":"twentytwentythree/cta"} /-->
+
 </main>
 <!-- /wp:group -->
-
-<!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">Pattern above footer goes here</p>
-<!-- /wp:paragraph -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
Adds the call to action block pattern to the home template, inside the main element.

I also tried an alternative where the pattern was inside a separate `<section>` between the `<main>` and the `<footer>`.
I switched to including it in the main element because I believe that if a section is used, it will need an aria-label.
I don't think `<aside>` would have been a good option either since it's a call to action.

In the pattern, I needed to place the opening `<?php` on the same line as the p tag, because there was an extra space before the first letter.