### PR TITLE
Search and archive templates: update spacing

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,13 +1,13 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var(--preset--spacing--70)","bottom":"var(--preset--spacing--70)"}}},"layout":{"inherit":true}} -->
-<main class="wp-block-group" style="margin-top:var(--preset--spacing--70);margin-bottom:var(--preset--spacing--70)">
-	<!-- wp:query-title {"type":"archive","align":"wide","style":{"spacing":{"margin":{"bottom":"6.4rem"}}}} /-->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
+	<!-- wp:query-title {"type":"archive","align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
 	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":false}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
-			<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"var(--wp--preset--spacing--40)","bottom":"var(--wp--preset--spacing--40)"}}}} /-->
+			<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--50)"} -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,13 +1,13 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var(--wp--preset--spacing--70)","bottom":"var(--wp--preset--spacing--70)"}}},"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"inherit":true}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
-	<!-- wp:query-title {"type":"search","align":"wide","style":{"spacing":{"margin":{"bottom":"6.4rem"}}}} /-->
+	<!-- wp:query-title {"type":"search","align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
 	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":false}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
-			<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"var(--preset--spacing--60)","bottom":"var(--preset--spacing--60)"}}}} /-->
+			<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} -->

--- a/theme.json
+++ b/theme.json
@@ -76,7 +76,7 @@
 					"name": "40"
 				},
 				{
-					"size": "clamp(2.5rem, 8vw, 6.5rem))",
+					"size": "clamp(2.5rem, 8vw, 6.5rem)",
 					"slug": "50",
 					"name": "50"
 				},


### PR DESCRIPTION
This PR includes a couple of changes, mainly adjusting the spacing variables in the search template:

- fixes a typo with the `spacing--50` preset
- replaces the spacing variables with this style: `var:preset|spacing|70` in the JSON markup (instead of this: `var(--wp--preset--spacing--70)`) (part of https://github.com/WordPress/twentytwentythree/issues/95, and mentioned here: https://github.com/WordPress/twentytwentythree/pull/55#discussion_r952127903)
- replaces a `spacing--60` with a `spacing--40`, as I thought the spacing looked slightly too big here

