### PR TITLE
fix fluid typography and block font sizes

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -233,25 +233,29 @@
 			"fontSizes": [
 				{
 					"fluid": {
-						"min": "0.875rem"
+						"min": "0.875rem",
+						"max": "1rem"
 					},
 					"size": "1rem",
 					"slug": "small"
 				},
 				{
 					"fluid": {
-						"min": "1rem"
+						"min": "1rem",
+						"max": "1.125rem"
 					},
 					"size": "1.125rem",
 					"slug": "medium"
 				},
 				{
 					"size": "1.75rem",
-					"slug": "large"
+					"slug": "large",
+					"fluid": false
 				},
 				{
 					"size": "2.25rem",
-					"slug": "x-large"
+					"slug": "x-large",
+					"fluid": false
 				},
 				{
 					"size": "10rem",
@@ -317,7 +321,7 @@
 			},
 			"core/post-excerpt": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"core/post-date": {
@@ -340,7 +344,6 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "400"
 				},
 				"elements": {


### PR DESCRIPTION
This addresses the issues of fluid typography and font-sizes of few blocks.

* Add `max` for `small` and `medium` to avoid max being set to a factor of 1.5 by default by Gutenberg.
* Add an explicit `fluid: false` for `large` and `x-large` to bypass fluid calculation. Ref: https://github.com/WordPress/gutenberg/pull/42757
* Remove the font-size for `post-title` block to inherit based on the set level. `h2` in single post, `h4` in home-page (addresses this [comment](https://github.com/WordPress/twentytwentythree/pull/94#issuecomment-1225369688))
* Update font size of `post-excerpt` to match figma.

### Screenshots

**Home page:**

| Before | After |
| --- | --- |
| <img width="763" alt="image" src="https://user-images.githubusercontent.com/1935113/186379793-07817fba-edd0-4828-a4b1-4669ce1a6418.png"> | <img width="763" alt="image" src="https://user-images.githubusercontent.com/1935113/186380351-65f4442f-4981-40d2-a311-92ae54f8db5f.png"> |

**Single post title:**

| Before | After |
| --- | --- |
| <img width="763" alt="image" src="https://user-images.githubusercontent.com/1935113/186380828-daf01d48-e004-410c-94f5-a3b4ba4f514a.png"> | <img width="763" alt="image" src="https://user-images.githubusercontent.com/1935113/186380607-1593d994-3d21-4844-bc90-d776d1b4d3d0.png"> |

**Paragraphs:**

| Before | After |
| --- | --- |
| <img width="698" alt="image" src="https://user-images.githubusercontent.com/1935113/186381733-299a7353-aee1-49a1-ac5a-d05ba23fd47a.png"> | <img width="698" alt="image" src="https://user-images.githubusercontent.com/1935113/186381892-25536ce3-2c0a-46d2-8d14-990141f73640.png"> |