### PR TITLE
Update home template

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -7,7 +7,7 @@
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
-			<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /-->
+			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--50)"} -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -25,6 +25,10 @@
 	</div>
 	<!-- /wp:query -->
 
+	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
+	<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
 	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 	<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 	<!-- wp:query-pagination-next {"label":"Older Posts"} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -15,7 +15,7 @@
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
-			<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /-->
+			<!-- wp:post-title {"level":3,"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
       	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -15,7 +15,7 @@
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
-			<!-- wp:post-title {"level":4,"isLink":true,"style":{"spacing":{"margin":{"top":"var(--wp--preset--spacing--40)","bottom":"var(--wp--preset--spacing--40)"}}}} /-->
+			<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
       	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -25,6 +25,15 @@
 	</div>
 	<!-- /wp:query -->
 
+	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+	<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+	<!-- /wp:query-pagination -->
+
+	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
+	<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
 	<!-- wp:pattern {"slug":"twentytwentythree/cta"} /-->
 
 </main>

--- a/templates/home.html
+++ b/templates/home.html
@@ -13,16 +13,6 @@
 	
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 	<div class="wp-block-query alignwide">
-		<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-		<div class="wp-block-group alignwide">
-			<!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
-			<h3 class="has-small-font-size" style="font-style:normal;font-weight:400;text-transform:uppercase">Latests posts</h3>
-			<!-- /wp:heading -->
-			<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"right"}} -->
-			<!-- wp:query-pagination-next {"label":"View more"} /-->
-			<!-- /wp:query-pagination -->
-		</div>
-		<!-- /wp:group -->
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 			<!-- wp:post-title {"level":4,"isLink":true,"style":{"spacing":{"margin":{"top":"var(--wp--preset--spacing--40)","bottom":"var(--wp--preset--spacing--40)"}}}} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -25,8 +25,8 @@
 	</div>
 	<!-- /wp:query -->
 
-	<!-- wp:separator {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
-	<hr class="wp-block-separator alignwide has-alpha-channel-opacity" style="margin-bottom:var(--wp--preset--spacing--60)"/>
+	<!-- wp:separator {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+	<hr class="wp-block-separator alignwide has-alpha-channel-opacity" style="margin-bottom:var(--wp--preset--spacing--40)"/>
 	<!-- /wp:separator -->
 
 	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,14 +1,14 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"inherit":true}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 
 	<!-- wp:image {"align":"wide"} -->
 	<figure class="wp-block-image alignwide"><img alt=""/></figure>
 	<!-- /wp:image -->
 
-	<!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
-	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60);">Mindblown: a blog about philosophy.</h2>
+	<!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}}} -->
+	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--50);">Mindblown: a blog about philosophy.</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,16 +1,16 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var(--wp--preset--spacing--70)","bottom":"var(--wp--preset--spacing--70)"}}},"layout":{"inherit":true}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60)">
 
 	<!-- wp:image {"align":"wide"} -->
 	<figure class="wp-block-image alignwide"><img alt=""/></figure>
 	<!-- /wp:image -->
-	
-	<!-- wp:heading {"align":"wide","style":{"typography":{"fontWeight":"400"},"spacing":{"margin":{"top":"var(--wp--preset--spacing--70)","bottom":"var(--wp--preset--spacing--70)"}}}} -->
-	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70);font-weight:400;">Mindblown: a blog about philosophy.</h2>
+
+	<!-- wp:heading {"align":"wide","style":{"typography":{"fontWeight":"400"},"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60);font-weight:400;">Mindblown: a blog about philosophy.</h2>
 	<!-- /wp:heading -->
-	
+
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
@@ -18,9 +18,9 @@
 			<!-- wp:post-title {"level":4,"isLink":true,"style":{"spacing":{"margin":{"top":"var(--wp--preset--spacing--40)","bottom":"var(--wp--preset--spacing--40)"}}}} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
-      <!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} -->
-	    <div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
-	    <!-- /wp:spacer -->  
+      	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
+	    <div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+	    <!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 	</div>
 	<!-- /wp:query -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -25,9 +25,9 @@
 	</div>
 	<!-- /wp:query -->
 
-	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
-	<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
+	<!-- wp:separator {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
+	<hr class="wp-block-separator alignwide has-alpha-channel-opacity" style="margin-bottom:var(--wp--preset--spacing--60)"/>
+	<!-- /wp:separator -->
 
 	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 	<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -7,8 +7,8 @@
 	<figure class="wp-block-image alignwide"><img alt=""/></figure>
 	<!-- /wp:image -->
 
-	<!-- wp:heading {"align":"wide","style":{"typography":{"fontWeight":"400"},"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
-	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60);font-weight:400;">Mindblown: a blog about philosophy.</h2>
+	<!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60);">Mindblown: a blog about philosophy.</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -7,7 +7,7 @@
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
-			<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /-->
+			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} -->

--- a/theme.json
+++ b/theme.json
@@ -343,6 +343,12 @@
 				}
 			},
 			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--preset--spacing--40)",
+						"top": "var(--wp--preset--spacing--40)"
+					}
+				},
 				"typography": {
 					"fontWeight": "400"
 				},

--- a/theme.json
+++ b/theme.json
@@ -499,13 +499,12 @@
 			"h6": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
-					"fontWeight": "400",
 					"textTransform": "uppercase"
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontWeight": "300",
+					"fontWeight": "400",
 					"lineHeight": "1.4"
 				}
 			},


### PR DESCRIPTION
This PR removes a section from the home template and tidies up the spacing, based on recent spacing preset changes:

- removes the 'Latest Posts' and 'View more' section, as discussed here: https://github.com/WordPress/twentytwentythree/issues/43#issuecomment-1222063777
- makes the default font-weight of all headings 400, based on the latest designs (and removes this opinion from the home template)
- adjusts the spacing value of the main heading and spacer block
- changes the spacing variable format in the JSON markup, as part of https://github.com/WordPress/twentytwentythree/issues/95) 