### PR TITLE
Update header and footer spacing

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -2,6 +2,6 @@
 <div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--60)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--60)">
 <!-- wp:site-title /-->
-<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>
+<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -2,6 +2,6 @@
 <div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--60)","top":"var(--wp--preset--spacing--30)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--60)">
 <!-- wp:site-title /-->
-<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>
+<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--60)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--60)">
 <!-- wp:site-title /-->
 <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--60)","top":"var(--wp--preset--spacing--30)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--60)">
+<div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--60)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--60)">
 <!-- wp:site-title /-->
 <!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>
 <!-- /wp:group --></div>

--- a/patterns/footer-default.php
+++ b/patterns/footer-default.php
@@ -6,9 +6,9 @@
  * Block Types: core/template-part/footer
  */
 ?>
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--40)"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--40)","bottom":"var(--wp--preset--spacing--40)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:site-title {"level":0} /-->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}},"layout":{"inherit":true}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:site-title {"level":0} /-->
 
 <!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right">

--- a/theme.json
+++ b/theme.json
@@ -542,9 +542,9 @@
 		"spacing": {
 			"blockGap": "1.5rem",
 			"padding": {
-				"top": "var(--wp--preset--spacing--40)",
+				"top": "var(--wp--preset--spacing--30)",
 				"right": "var(--wp--preset--spacing--30)",
-				"bottom": "var(--wp--preset--spacing--40)",
+				"bottom": "var(--wp--preset--spacing--30)",
 				"left": "var(--wp--preset--spacing--30)"
 			}
 		},

--- a/theme.json
+++ b/theme.json
@@ -542,9 +542,9 @@
 		"spacing": {
 			"blockGap": "1.5rem",
 			"padding": {
-				"top": "0px",
+				"top": "var(--wp--preset--spacing--30)",
 				"right": "var(--wp--preset--spacing--30)",
-				"bottom": "0px",
+				"bottom": "var(--wp--preset--spacing--30)",
 				"left": "var(--wp--preset--spacing--30)"
 			}
 		},

--- a/theme.json
+++ b/theme.json
@@ -542,9 +542,9 @@
 		"spacing": {
 			"blockGap": "1.5rem",
 			"padding": {
-				"top": "var(--wp--preset--spacing--30)",
+				"top": "var(--wp--preset--spacing--40)",
 				"right": "var(--wp--preset--spacing--30)",
-				"bottom": "var(--wp--preset--spacing--30)",
+				"bottom": "var(--wp--preset--spacing--40)",
 				"left": "var(--wp--preset--spacing--30)"
 			}
 		},


### PR DESCRIPTION
~This PR is to help test out https://github.com/WordPress/gutenberg/pull/43576/~

I've updated this PR so that it should be in a good state to bring in, now that the above GB PR has been merged.

The changes include:

- adjusts root vertical padding so that it's consistent (top and bottom now spacing-40)
- removes the top padding from the header and bottom padding from the footer, as they're no longer needed with the root padding change
- changes the spacing variables in the JSON markup (part of https://github.com/WordPress/twentytwentythree/issues/95)