### PR TITLE
Update comments area

### DIFF
--- a/parts/comments.html
+++ b/parts/comments.html
@@ -3,28 +3,27 @@
 <div class="wp-block-comments"><!-- wp:comments-title /-->
 
 <!-- wp:comment-template -->
-<!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"40px"} -->
+<!-- wp:columns {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-columns" style="margin-bottom:var(--wp--preset--spacing--40)">
+<!-- wp:column {"width":"40px"} -->
 <div class="wp-block-column" style="flex-basis:40px"><!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:comment-author-name {"fontSize":"small"} /-->
+<div class="wp-block-column"><!-- wp:comment-author-name /-->
 
 <!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex"}} -->
-<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px"><!-- wp:comment-date {"fontSize":"small"} /-->
-
-<!-- wp:comment-edit-link {"fontSize":"small"} /--></div>
+<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px"><!-- wp:comment-date /--><!-- wp:comment-edit-link /--></div>
 <!-- /wp:group -->
 
 <!-- wp:comment-content /-->
 
-<!-- wp:comment-reply-link {"fontSize":"small"} /--></div>
+<!-- wp:comment-reply-link /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 <!-- /wp:comment-template -->
 
-<!-- wp:comments-pagination -->
+<!-- wp:comments-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <!-- wp:comments-pagination-previous /-->
 
 <!-- wp:comments-pagination-numbers /-->

--- a/theme.json
+++ b/theme.json
@@ -312,13 +312,6 @@
 					}
 				}
 			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--preset--spacing--30)"
-					}
-				}
-			},
 			"core/post-excerpt": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)"
@@ -564,6 +557,11 @@
 			"area": "footer",
 			"name": "footer",
 			"title": "Footer"
+		},
+		{
+			"area": "uncategorized",
+			"name": "comments",
+			"title": "Comments"
 		}
 	]
 }

--- a/theme.json
+++ b/theme.json
@@ -76,7 +76,7 @@
 					"name": "40"
 				},
 				{
-					"size": "clamp(2.5rem, 8vw, 6.5rem))",
+					"size": "clamp(2.5rem, 8vw, 6.5rem)",
 					"slug": "50",
 					"name": "50"
 				},
@@ -359,6 +359,122 @@
 								"textDecoration": "none"
 							}
 						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/comments-title":{
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				},
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--preset--spacing--40)"
+					}
+				}
+			},
+			"core/comment-author-name": {
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/comment-date": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/comment-edit-link": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/comment-reply-link": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/comments-pagination": {
+				"spacing": {
+					"margin": {
+						"top": "var(--wp--preset--spacing--40)"
+					}
+				},
+				"elements": {
+					"link": {
 						"typography": {
 							"textDecoration": "none"
 						}


### PR DESCRIPTION
1. Adds the comment template part, closes https://github.com/WordPress/twentytwentythree/issues/106
2. Removes the post-comments styles, closes https://github.com/WordPress/twentytwentythree/issues/112
3. Updates the font sizes and link underlines
4. Updates the spacing between the comment blocks
5. Updates the comment query pagination (I did not find a figma design for this)

I was not sure if the comment author avatar was supposed to have a dashed border or if this was a placeholder?
[Figma](https://www.figma.com/file/ohYEHkZzGjOse46NceTfj5/Twenty-Twenty-Three?node-id=301%3A441)

How to test:

1. Make sure that your test site has comments and nested replies
2. In the WordPress admin area, enable the comment pagination under Settings, discussion, "break comments into pages"


Sorry about the meh screenshot, I took the full page screenshot with Chrome.
![comments area](https://user-images.githubusercontent.com/7422055/186611057-045c3a7b-2cb7-476f-a864-02e6f2045c1c.png)
