### PR TITLE
404: fix spacing preset, use the new layout setting on the group.

### DIFF
--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -14,8 +14,8 @@
 <p class="has-text-align-center"><?php echo esc_html_x( 'This page could not be found.', 'Message to convey that a webpage could not be found', 'twentytwentythree' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer {"height":"var(--wp--preset--spacing--100)"} -->
-<div style="height:var(--wp--preset--spacing--100)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var(--wp--preset--spacing--40)"} -->
+<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'label', 'twentytwentythree' ); ?>","placeholder":"<?php echo esc_html_x( 'Search...', 'placeholder for search field', 'twentytwentythree' ); ?>","showLabel":false,"width":70,"widthUnit":"%","buttonText":"<?php esc_html_e( 'Search', 'twentytwentythree' ); ?>","buttonUseIcon":true,"align":"center"} /-->
+<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'label', 'twentytwentythree' ); ?>","placeholder":"<?php echo esc_html_x( 'Search...', 'placeholder for search field', 'twentytwentythree' ); ?>","showLabel":false,"width":100,"widthUnit":"%","buttonText":"<?php esc_html_e( 'Search', 'twentytwentythree' ); ?>","buttonUseIcon":true,"align":"center"} /-->

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -5,9 +5,8 @@
  * Inserter: no
  */
 ?>
-
-<!-- wp:heading {"className":"has-text-align-center"} -->
-<h2 class="has-text-align-center"><?php echo esc_html_x( '404', 'Error code for a webpage that is not found.', 'twentytwentythree' ); ?></h2>
+<!-- wp:heading {"level":1,"className":"has-text-align-center"} -->
+<h1 class="has-text-align-center"><?php echo esc_html_x( '404', 'Error code for a webpage that is not found.', 'twentytwentythree' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"center"} -->

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -6,11 +6,11 @@
  */
 ?>
 
-<!-- wp:heading {"className":"has-text-align-center","fontSize":"xx-large"} -->
-<h2 class="has-text-align-center has-xx-large-font-size"><?php echo esc_html_x( '404', 'Error code for a webpage that is not found.', 'twentytwentythree' ); ?></h2>
+<!-- wp:heading {"className":"has-text-align-center"} -->
+<h2 class="has-text-align-center"><?php echo esc_html_x( '404', 'Error code for a webpage that is not found.', 'twentytwentythree' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+<!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php echo esc_html_x( 'This page could not be found.', 'Message to convey that a webpage could not be found', 'twentytwentythree' ); ?></p>
 <!-- /wp:paragraph -->
 

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,11 +1,9 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main"} -->
-<main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
 <!-- wp:pattern {"slug":"twentytwentythree/hidden-404"} /-->
-</div>
-<!-- /wp:group --></main>
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
The 404 page used spacing preset 100, which had no value and was not working. This PR updates the preset to 40.

The template also had two group blocks. One group was removed, and the new constrained layout setting was used on the `<main>` group instead.

_The width of the search was reset from 70% to 100% (of the content width), because in the design, the search is wider than the 404 heading. The 404 heading is much larger in the template than in the design, so I'm not sure which is correct._
