### PR TITLE
WIP: Update templates to use the new layout setting

### DIFF
--- a/parts/comments.html
+++ b/parts/comments.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:comments -->
 <div class="wp-block-comments"><!-- wp:comments-title /-->
 

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--60)","top":"var(--wp--preset--spacing--30)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--60)">
 <!-- wp:site-title /-->

--- a/patterns/footer-default.php
+++ b/patterns/footer-default.php
@@ -6,7 +6,7 @@
  * Block Types: core/template-part/footer
  */
 ?>
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--40)"}}},"layout":{"inherit":true}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--40)"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--40)","bottom":"var(--wp--preset--spacing--40)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:site-title {"level":0} /-->
 

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
-<main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
+<main class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 <!-- wp:pattern {"slug":"twentytwentythree/hidden-404"} /-->
 </div>

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,9 +1,9 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 	<!-- wp:query-title {"type":"archive","align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
-	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":false}} -->
+	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->

--- a/templates/blank.html
+++ b/templates/blank.html
@@ -1,1 +1,1 @@
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->

--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -3,6 +3,7 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
 	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /-->
+
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template -->

--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"4.8rem","bottom":"4.8rem"}}}} /-->
+	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /-->
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template -->

--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /-->
+	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} /-->
 
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">

--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} /-->
+	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /-->
 
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">

--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -1,10 +1,9 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
 	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"4.8rem","bottom":"4.8rem"}}}} /-->
-
-	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide"} -->
+	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template -->
 			<!-- wp:group {"style":{"border":{"top":{"width":"1px"},"right":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,17 +1,17 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var(--wp--preset--spacing--70)","bottom":"var(--wp--preset--spacing--70)"}}},"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var(--wp--preset--spacing--70)","bottom":"var(--wp--preset--spacing--70)"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 
 	<!-- wp:image {"align":"wide"} -->
 	<figure class="wp-block-image alignwide"><img alt=""/></figure>
 	<!-- /wp:image -->
-	
+
 	<!-- wp:heading {"align":"wide","style":{"typography":{"fontWeight":"400"},"spacing":{"margin":{"top":"var(--wp--preset--spacing--70)","bottom":"var(--wp--preset--spacing--70)"}}}} -->
 	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70);font-weight:400;">Mindblown: a blog about philosophy.</h2>
 	<!-- /wp:heading -->
-	
-	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
+
+	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 		<div class="wp-block-group alignwide">
@@ -30,7 +30,7 @@
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
       <!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} -->
 	    <div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
-	    <!-- /wp:spacer -->  
+	    <!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 	</div>
 	<!-- /wp:query -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -12,16 +12,15 @@
 	<!-- /wp:heading -->
 
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
-
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 			<!-- wp:post-title {"level":3,"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
-      <!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
-	    <div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
-	    <!-- /wp:spacer -->
+		<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
+		<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 	</div>
 	<!-- /wp:query -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -18,9 +18,9 @@
 			<!-- wp:post-title {"level":3,"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
-		<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
-		<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
+			<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
+			<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 	</div>
 	<!-- /wp:query -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
+<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"constrained"}},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:post-title {"isLink":true,"align":"wide"} /-->
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,14 +2,14 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:group {"layout":{"inherit":true}} -->
+	<!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:post-featured-image {"align":"wide"} /-->
 		<!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}}} /-->
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 
 	<!-- wp:spacer {"height":"var(--wp--preset--spacing--40)"} -->
 	<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,9 +1,9 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 	<!-- wp:query-title {"type":"search","align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
-	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":false}} -->
+	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -2,16 +2,16 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:group {"layout":{"inherit":true}} -->
+	<!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:post-featured-image {"align":"wide"} /-->
 		<!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}}} /-->
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 
-	<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"inherit":true}} -->
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 		<!-- wp:separator {"opacity":"css","align":"wide","className":"is-style-wide"} -->
 		<hr class="wp-block-separator alignwide has-css-opacity is-style-wide"/>


### PR DESCRIPTION
Update templates to use the new layout setting for container blocks:

`"layout":{"type":"constrained"}` : Inner blocks has wide and full width options
`"layout":{"type":"default"}:` inner blocks do not have wide and full width options
These replace `"layout":{"inherit":true} and false`

_Please feel free to pick a template and add it to the same branch._

Closes https://github.com/WordPress/twentytwentythree/issues/98