### PR TITLE
Remove duplicate elements key from site-title

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -540,13 +540,6 @@
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "normal",
 					"lineHeight": "1.4"
-				},
-				"elements": {
-					"link": {
-						"typography": {
-							"textDecoration": "none"
-						}
-					}
 				}
 			}
 		},


### PR DESCRIPTION
Quick PR that fixes #124. Removes a duplicate `elements` key from the site-title block in theme.json.