### PR TITLE
Remove default font size from button elements

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -556,9 +556,6 @@
 					"background": "var(--wp--preset--color--primary)",
 					"text": "var(--wp--preset--color--contrast)"
 				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
-				},
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",


### PR DESCRIPTION
This is a small PR to remove the default font size from button elements in theme.json, as mentioned here: https://github.com/WordPress/twentytwentythree/issues/75.

It was previously set to the medium font size preset, which works in most cases when a button is added to the body, as the body is also set to medium by default. However, if a button element is added to another section or group that has a different font size, it would be nice if the button just inherited the container font size, rather than setting its own specific font size.

Closes https://github.com/WordPress/twentytwentythree/issues/75.