### PR TITLE
Make all font presets fluid, make h1-6 use var()

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -602,7 +602,7 @@
 			},
 			"h2": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"fontSize": "clamp(2.625rem, calc(2.625rem + ((1vw - 0.48rem) * 8.4135)), 3.25rem)",
 					"lineHeight": "1.2"
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -598,7 +598,7 @@
 			},
 			"h1": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
+					"fontSize": "3.625rem",
 					"lineHeight": "1.2"
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -613,7 +613,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				}
 			},
 			"h5": {

--- a/theme.json
+++ b/theme.json
@@ -258,7 +258,7 @@
 				{
 					"fluid": {
 						"min": "1rem",
-						"max": "4.125rem"
+						"max": "1.125rem"
 					},
 					"size": "1.125rem",
 					"slug": "medium"

--- a/theme.json
+++ b/theme.json
@@ -250,7 +250,7 @@
 				{
 					"fluid": {
 						"min": "0.875rem",
-						"max": "3rem"
+						"max": "1rem"
 					},
 					"size": "1rem",
 					"slug": "small"

--- a/theme.json
+++ b/theme.json
@@ -625,7 +625,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--medium)",
 					"textTransform": "uppercase"
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -250,7 +250,7 @@
 				{
 					"fluid": {
 						"min": "0.875rem",
-						"max": "1rem"
+						"max": "3rem"
 					},
 					"size": "1rem",
 					"slug": "small"
@@ -258,7 +258,7 @@
 				{
 					"fluid": {
 						"min": "1rem",
-						"max": "1.125rem"
+						"max": "4.125rem"
 					},
 					"size": "1.125rem",
 					"slug": "medium"
@@ -266,13 +266,18 @@
 				{
 					"size": "1.75rem",
 					"slug": "large",
-					"fluid": false
+					"fluid": {
+						"min": "1.75rem",
+						"max": "15rem"
+					}
 				},
 				{
 					"size": "2.25rem",
 					"slug": "x-large",
-					"fluid": false
-				},
+					"fluid": {
+						"min": "2rem",
+						"max": "10rem"
+					}				},
 				{
 					"size": "10rem",
 					"slug": "xx-large",
@@ -593,24 +598,24 @@
 			},
 			"h1": {
 				"typography": {
-					"fontSize": "3.625rem",
+					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"lineHeight": "1.2"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontSize": "clamp(2.625rem, calc(2.625rem + ((1vw - 0.48rem) * 8.4135)), 3.25rem)",
+					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"lineHeight": "1.2"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "2.25rem"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "clamp(1.75rem, calc(1.75rem + ((1vw - 0.48rem) * 8.4135)), 1.875rem)"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"h5": {
@@ -622,7 +627,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"textTransform": "uppercase"
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -268,7 +268,7 @@
 					"slug": "large",
 					"fluid": {
 						"min": "1.75rem",
-						"max": "15rem"
+						"max": "1.875rem"
 					}
 				},
 				{

--- a/theme.json
+++ b/theme.json
@@ -274,10 +274,8 @@
 				{
 					"size": "2.25rem",
 					"slug": "x-large",
-					"fluid": {
-						"min": "2rem",
-						"max": "10rem"
-					}				},
+					"fluid": false
+				},
 				{
 					"size": "10rem",
 					"slug": "xx-large",

--- a/theme.json
+++ b/theme.json
@@ -608,7 +608,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"fontSize": "var(--wp--preset--font-size--x-large)"
 				}
 			},
 			"h4": {


### PR DESCRIPTION
Fluidity experiment! Example for issue: **Fluid Typography Question**
Fixes #158 

## Changed lines 249-283
- Gave fluid range to 'large' and 'x-large' presets (fluid had been set to false).
- I used extreme sizes to highlight what I'm talking about (not because I think these particular sizes are right).

## Changed lines 599-633 
- Removed all h1–h6 clamp and standard size customizations.
- Instead, I used presets on all h1–h6 sizes

I focused only on playing with fluidity, so refer to the issue I created if doing it this way breaks something else or conflicts with another priority. 

![fluid-twentytwentythree](https://user-images.githubusercontent.com/113260898/189548345-3bb0770f-b204-4ae4-aa1d-a85129408694.gif)
