### PR TITLE
Update query block markup and crop featured images

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -6,7 +6,7 @@
 	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
+			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,7 +14,7 @@
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
+			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 			<!-- wp:post-title {"level":3,"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -22,17 +22,17 @@
 			<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
 			<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
+
+		<!-- wp:separator {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+		<hr class="wp-block-separator alignwide has-alpha-channel-opacity" style="margin-bottom:var(--wp--preset--spacing--40)"/>
+		<!-- /wp:separator -->
+
+		<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+		<!-- /wp:query-pagination -->
 	</div>
 	<!-- /wp:query -->
-
-	<!-- wp:separator {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
-	<hr class="wp-block-separator alignwide has-alpha-channel-opacity" style="margin-bottom:var(--wp--preset--spacing--40)"/>
-	<!-- /wp:separator -->
-
-	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
-	<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-	<!-- /wp:query-pagination -->
 
 	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
 	<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,7 +11,7 @@
 	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--50);">Mindblown: a blog about philosophy.</h2>
 	<!-- /wp:heading -->
 
-	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
+	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,7 +11,7 @@
 	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--50);">Mindblown: a blog about philosophy.</h2>
 	<!-- /wp:heading -->
 
-	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
+	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
 			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,32 +1,24 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"constrained"}},"tagName":"main"} -->
-<main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
-<!-- wp:post-title {"isLink":true,"align":"wide"} /-->
-
-<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
-
-<!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"650px"} -->
-<div class="wp-block-column" style="flex-basis:650px"><!-- wp:post-excerpt /-->
-
-<!-- wp:post-date {"isLink":true,"format":"F j, Y"} /--></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":""} -->
-<div class="wp-block-column"></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-
-<!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} -->
-<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-<!-- /wp:post-template -->
-
-<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-<!-- wp:query-pagination-previous /-->
-<!-- wp:query-pagination-next /-->
-<!-- /wp:query-pagination --></main>
-<!-- /wp:query -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
+	<div class="wp-block-query alignwide">
+		<!-- wp:post-template {"align":"wide"} -->
+			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
+			<!-- wp:post-title {"isLink":true,"align":"wide"} /-->
+			<!-- wp:post-excerpt /-->
+			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
+			<!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} -->
+			<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+	<!-- /wp:post-template -->
+	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination --></div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:post-title {"isLink":true,"align":"wide"} /-->
 
-<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
+<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"650px"} -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -6,7 +6,7 @@
 	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
+			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->


### PR DESCRIPTION
This PR addresses a few issues noticed while demoing the theme, listed in https://github.com/WordPress/twentytwentythree/issues/164.

- Fixes the query pagination on the home template (the pagination block was outside of the query block)
- ~Changes the home and index query blocks to a default layout, allowing them to fill the align wide width~ (no longer needed with this fix https://github.com/WordPress/gutenberg/pull/44144)
- Crops the featured images on the home, index, search, and archive templates, to help keep the images and titles aligned within the query block

Cropped featured images:
| Before | After |
| ------ | ----- | 
| <img width="1043" alt="image" src="https://user-images.githubusercontent.com/1645628/190015671-a405219b-bbf9-4d9d-a64c-a80ed32a4107.png"> | <img width="1043" alt="image" src="https://user-images.githubusercontent.com/1645628/190015725-56f98621-63cf-4ae2-b7be-be855ffcc640.png"> |