### PR TITLE
Add Block-out style variation

### DIFF
--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -1,0 +1,168 @@
+{
+	"title": "Block-out",
+	"settings": {
+		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#FF2D34",
+						"#FF7E7E"
+					],
+					"slug": "default-filter",
+					"name": "Default filter"
+				}
+			],
+			"palette": [
+				{
+					"color": "#ff5252",
+					"name": "Base",
+					"slug": "base"
+				},
+				{
+					"color": "#252525",
+					"name": "Contrast",
+					"slug": "contrast"
+				},
+				{
+					"color": "#ffffff",
+					"name": "Primary",
+					"slug": "primary"
+				},
+				{
+					"color": "#ff2d34",
+					"name": "Secondary",
+					"slug": "secondary"
+				},
+				{
+					"color": "#ff7e7e",
+					"name": "Tertiary",
+					"slug": "tertiary"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "800px"
+		},
+		"typography": {
+			"fontSizes": [
+				{
+					"fluid": {
+						"max": "1rem",
+						"min": "0.875rem"
+					},
+					"size": "1rem",
+					"slug": "small"
+				},
+				{
+					"fluid": {
+						"max": "1.125rem",
+						"min": "1rem"
+					},
+					"size": "1.125rem",
+					"slug": "medium"
+				},
+				{
+					"fluid": false,
+					"size": "1.75rem",
+					"slug": "large"
+				},
+				{
+					"fluid": false,
+					"size": "2.25rem",
+					"slug": "x-large"
+				},
+				{
+					"fluid": {
+						"max": "20rem",
+						"min": "4rem"
+					},
+					"size": "10rem",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/image": {
+				"border": {
+					"radius": "8px"
+				},
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"core/post-featured-image": {
+				"border": {
+					"radius": "8px"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"width": "1px"
+				}
+			},
+			"core/search": {
+				"border": {
+					"radius": "8px"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "8px"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)",
+					"fontStyle": "italic",
+					"fontWeight": "400"
+				}
+			},
+			"h2": {
+				"color": {
+					"text": "var(--wp--preset--color--primary)"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontWeight": "400"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)",
+					"fontStyle": "italic"
+				}
+			},
+			"link": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)",
+					"fontStyle": "italic",
+					"fontWeight": "400"
+				}
+			}
+		},
+		"spacing": {
+			"padding": {
+				"bottom": "0px",
+				"top": "0px"
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--dm-sans)"
+		}
+	},
+	"version": 2,
+	"$schema": "https://schemas.wp.org/trunk/theme.json"
+}

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -102,6 +102,15 @@
 					"fontSize": "var(--wp--preset--font-size--large)"
 				}
 			},
+			"core/post-content": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
+					}
+				}
+			},
 			"core/post-featured-image": {
 				"border": {
 					"radius": "8px"

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -5,8 +5,8 @@
 			"duotone": [
 				{
 					"colors": [
-						"#FF2D34",
-						"#FF7E7E"
+						"#E2161D",
+						"#FF9C9C"
 					],
 					"slug": "default-filter",
 					"name": "Default filter"

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -84,6 +84,11 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/avatar": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
 			"core/image": {
 				"border": {
 					"radius": "8px"
@@ -110,6 +115,11 @@
 			"core/search": {
 				"border": {
 					"radius": "8px"
+				}
+			},
+			"core/site-logo": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
 				}
 			},
 			"core/site-title": {


### PR DESCRIPTION
This PR adds the Block-out style variation, including the changes mentioned [here](https://github.com/WordPress/twentytwentythree/issues/125#issuecomment-1239673223):

- Changed duotone shadow color to #E2161D
- Changed duotone highlight color to #FF9C9C
- Added duotone effect to site logo and avatars