### PR TITLE
Add Sherbet variation

### DIFF
--- a/styles/sherbet.json
+++ b/styles/sherbet.json
@@ -1,0 +1,206 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Sherbet",
+	"settings": {
+		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"rgb(81, 82, 213)",
+						"rgb(121, 238, 196)",
+						"rgb(236, 249, 87)",
+						"rgb(247, 69, 204)"
+					],
+					"name": "Default filter",
+					"slug": "default-filter"
+				}
+			],
+			"gradients": [
+				{
+					"gradient": "linear-gradient(135deg, var(--wp--preset--color--primary) 0%, var(--wp--preset--color--secondary) 50%, var(--wp--preset--color--tertiary) 100%)",
+					"name": "Primary to Secondary to Tertiary",
+					"slug": "primary-secondary-tertiary"
+				}
+			],
+			"palette": [
+				{
+					"color": "#FFFFFF",
+					"name": "Base",
+					"slug": "base"
+				},
+				{
+					"color": "#000000",
+					"name": "Contrast",
+					"slug": "contrast"
+				},
+				{
+					"color": "#FFCCFF",
+					"name": "Primary",
+					"slug": "primary"
+				},
+				{
+					"color": "#FFFFCC",
+					"name": "Secondary",
+					"slug": "secondary"
+				},
+				{
+					"color": "#CCFFFF",
+					"name": "Tertiary",
+					"slug": "tertiary"
+				}
+			]
+		},
+		"typography": {
+			"fontSizes": [
+				{
+					"size": "0.75rem",
+					"slug": "x-small"
+				},
+				{
+					"fluid": {
+						"min": "0.875rem"
+					},
+					"size": "1rem",
+					"slug": "small"
+				},
+				{
+					"fluid": {
+						"min": "1rem"
+					},
+					"size": "1.125rem",
+					"slug": "medium"
+				},
+				{
+					"size": "1.75rem",
+					"slug": "large"
+				},
+				{
+					"size": "2.25rem",
+					"slug": "x-large"
+				},
+				{
+					"size": "2.75rem",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/heading": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"fontWeight": "500",
+					"textTransform": "uppercase"
+				}
+			},
+			"core/post-content": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
+					}
+				}
+			},
+			"core/post-featured-image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				},
+				"border": {
+					"color": "var(--wp--preset--color--tertiary)",
+					"style": "solid"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontWeight": "500",
+					"textTransform": "uppercase"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
+			"core/template-part": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"fontWeight": "400",
+					"textTransform": "uppercase"
+				}
+			}
+		},
+		"color": {
+			"gradient": "var(--wp--preset--gradient--primary-secondary-tertiary)"
+		},
+		"elements": {
+			"button": {
+				":active": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
+				":hover": {
+					"color": {
+						"gradient": "radial-gradient(ellipse at top left, rgba(236, 249, 87, 1) 15% , transparent 100%) fixed, radial-gradient(ellipse at bottom left, rgba(247, 69, 204, 1) 15% , transparent 100%) fixed, radial-gradient(ellipse at top right, rgba(121, 238, 196, 1) 15% , transparent 100%) fixed, radial-gradient(ellipse at bottom right, rgba(81, 82, 213, 1) 15% , transparent 100%) fixed",
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
+				"border": {
+					"radius": "99999px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--base)",
+					"gradient": "radial-gradient(ellipse at bottom right, rgba(236, 249, 87, 1) 15% , transparent 100%) fixed, radial-gradient(ellipse at top right, rgba(247, 69, 204, 1) 15% , transparent 100%) fixed, radial-gradient(ellipse at bottom left, rgba(121, 238, 196, 1) 15% , transparent 100%) fixed, radial-gradient(ellipse at bottom left, rgba(81, 82, 213, 1) 15% , transparent 100%) fixed",
+					"text": "var(--wp--preset--color--contrast)"
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"fontWeight": "400",
+					"textTransform": "uppercase"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			}
+		},
+		"typography": {
+			"fontSize": "var(--wp--preset--font-size--small)",
+			"fontFamily": "var(--wp--preset--font-family--inter)"
+		}
+	}
+}

--- a/styles/sherbet.json
+++ b/styles/sherbet.json
@@ -167,32 +167,7 @@
 					"textTransform": "uppercase"
 				}
 			},
-			"h1": {
-				"typography": {
-					"fontWeight": "500"
-				}
-			},
-			"h2": {
-				"typography": {
-					"fontWeight": "500"
-				}
-			},
-			"h3": {
-				"typography": {
-					"fontWeight": "500"
-				}
-			},
-			"h4": {
-				"typography": {
-					"fontWeight": "500"
-				}
-			},
-			"h5": {
-				"typography": {
-					"fontWeight": "500"
-				}
-			},
-			"h6": {
+			"heading": {
 				"typography": {
 					"fontWeight": "500"
 				}


### PR DESCRIPTION
I wasn't able to push directly to the existing PR for the Sherbet variation, so in the interests of including this variation in Beta 1, I've created a separate PR.

This includes all the work from https://github.com/WordPress/twentytwentythree/pull/161, addresses the review comments, adds the duotone filter to the featured image block and adds the [button styles](https://github.com/WordPress/twentytwentythree/issues/104#issuecomment-1249503806) from Retroactive.

We can make further changes in additional PRs if needed.