### PR TITLE
Add spacer block to post meta pattern

### DIFF
--- a/patterns/post-meta.php
+++ b/patterns/post-meta.php
@@ -7,6 +7,10 @@
  * Block Types: core/template-part/post-meta
  */
 ?>
+<!-- wp:spacer {"height":"0"} -->
+<div style="height:0" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 	<!-- wp:separator {"opacity":"css","align":"wide","className":"is-style-wide"} -->


### PR DESCRIPTION
This adds a spacer block to the start of the post meta pattern, which acts as a 'clear fix' to clear any alignments from the post content.

| Before | After |
| ------ | ----- |
| ![before](https://user-images.githubusercontent.com/1645628/191235006-200fabe1-4b4f-4d8d-b388-6afebe2472fe.png) | ![after](https://user-images.githubusercontent.com/1645628/191235233-20b05730-9f80-4d32-b4db-2208d5216119.png) |

Fixes #148.