### PR TITLE
Styling tweaks to "Block out" variation

### DIFF
--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -138,7 +138,8 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--xx-large)"
+					"fontSize": "var(--wp--preset--font-size--xx-large)",
+					"lineHeight": "1.1"
 				}
 			}
 		},

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -1,5 +1,5 @@
 {
-	"title": "Block-out",
+	"title": "Block out",
 	"settings": {
 		"color": {
 			"duotone": [
@@ -114,6 +114,11 @@
 			"core/post-featured-image": {
 				"border": {
 					"radius": "8px"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
 				}
 			},
 			"core/quote": {


### PR DESCRIPTION
Thanks for adding Block out @mikachan! I made a few small tweaks in this PR:

• Removed the hyphen in the variation title (so it will display in the style variation tile as "Block out")
• Reduced the size of the Post Title

I was also wondering if you could help me reduce the line height for the XXL typography used on the Site Title? I wasn't totally sure how it works with the clamp sizes but ideally it would look more like this at the largest size:

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/77359364/191363216-a9167799-5976-4e69-b06e-39cfcc8e3441.png"> | <img src="https://user-images.githubusercontent.com/77359364/191363268-c888a91e-d1b7-45a3-8b61-7ee046420066.png"> |

Thank you!!