### PR TITLE
Variation Block out: fix font and color issues

### DIFF
--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -73,7 +73,7 @@
 				},
 				{
 					"fluid": {
-						"max": "20rem",
+						"max": "14rem",
 						"min": "4rem"
 					},
 					"size": "10rem",
@@ -114,11 +114,14 @@
 			"core/post-featured-image": {
 				"border": {
 					"radius": "8px"
+				},
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
 				}
 			},
 			"core/post-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)"
+				"color": {
+					"text": "var(--wp--preset--color--primary)"
 				}
 			},
 			"core/quote": {
@@ -139,7 +142,17 @@
 			"core/site-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"lineHeight": "1.1"
+					"lineHeight": "1.1",
+					"textTransform": "lowercase"
+				}
+			},
+			"core/query": {
+				"elements": {
+					"h3": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
+					}
 				}
 			}
 		},
@@ -152,11 +165,6 @@
 					"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)",
 					"fontStyle": "italic",
 					"fontWeight": "400"
-				}
-			},
-			"h2": {
-				"color": {
-					"text": "var(--wp--preset--color--primary)"
 				}
 			},
 			"h6": {

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -108,6 +108,11 @@
 						"color": {
 							"text": "var(--wp--preset--color--contrast)"
 						}
+					},
+					"h1": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
 					}
 				}
 			},
@@ -165,6 +170,11 @@
 					"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)",
 					"fontStyle": "italic",
 					"fontWeight": "400"
+				}
+			},
+			"h1": {
+				"color": {
+					"text": "var(--wp--preset--color--primary)"
 				}
 			},
 			"h6": {

--- a/templates/home.html
+++ b/templates/home.html
@@ -7,8 +7,8 @@
 	<figure class="wp-block-image alignwide"><img alt=""/></figure>
 	<!-- /wp:image -->
 
-	<!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}}} -->
-	<h2 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--50);">Mindblown: a blog about philosophy.</h2>
+	<!-- wp:heading {"level":1,"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}}} -->
+	<h1 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--50)">Mindblown: a blog about philosophy.</h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->


### PR DESCRIPTION
This fixes the following

* limit the max size of the xx-large font to 14rem
* remove color for `h2` and set it to `post-title`
* remove explicit font-size setting to post-title, it inherits the right size with the fix #191 
* add duotone for featured-image

Removing the color for `h2` turns the heading in the homepage to `contrast` color which is expected. However, the design suggests the color to be `primary` which cannot be set in a variation.

Frontend:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/1935113/191913343-a9ec39e7-bf01-44f6-bd80-76d9aeb241a0.png">

Design:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/1935113/191913428-929cb5c7-f527-48d1-a0dc-0aaab254ea83.png">


Fixes: #192 