### PR TITLE
Variation Sherbet: fix fluid typography and font-size of various blocks

### DIFF
--- a/styles/sherbet.json
+++ b/styles/sherbet.json
@@ -54,32 +54,38 @@
 		"typography": {
 			"fontSizes": [
 				{
+					"fluid": false,
 					"size": "0.75rem",
 					"slug": "x-small"
 				},
 				{
 					"fluid": {
-						"min": "0.875rem"
+						"min": "0.875rem",
+						"max": "1rem"
 					},
 					"size": "1rem",
 					"slug": "small"
 				},
 				{
 					"fluid": {
-						"min": "1rem"
+						"min": "1rem",
+						"max": "1.125rem"
 					},
 					"size": "1.125rem",
 					"slug": "medium"
 				},
 				{
+					"fluid": false,
 					"size": "1.75rem",
 					"slug": "large"
 				},
 				{
+					"fluid": false,
 					"size": "2.25rem",
 					"slug": "x-large"
 				},
 				{
+					"fluid": false,
 					"size": "2.75rem",
 					"slug": "xx-large"
 				}
@@ -88,14 +94,21 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/heading": {
+			"core/comment-author-name": {
 				"typography": {
-					"fontWeight": "500"
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"textTransform": "initial"
+				}
+			},
+			"core/comment-content": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"textTransform": "initial"
 				}
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": "500",
 					"textTransform": "uppercase"
 				}
@@ -107,6 +120,11 @@
 							"text": "var(--wp--preset--color--contrast)"
 						}
 					}
+				}
+			},
+			"core/post-date": {
+				"typography": {
+					"textTransform": "uppercase"
 				}
 			},
 			"core/post-featured-image": {

--- a/styles/sherbet.json
+++ b/styles/sherbet.json
@@ -75,17 +75,26 @@
 					"slug": "medium"
 				},
 				{
-					"fluid": false,
+					"fluid": {
+						"min": "1.5rem",
+						"max": "1.75rem"
+					},
 					"size": "1.75rem",
 					"slug": "large"
 				},
 				{
-					"fluid": false,
+					"fluid": {
+						"min": "2rem",
+						"max": "2.25rem"
+					},
 					"size": "2.25rem",
 					"slug": "x-large"
 				},
 				{
-					"fluid": false,
+					"fluid": {
+						"min": "2.5rem",
+						"max": "2.75rem"
+					},
 					"size": "2.75rem",
 					"slug": "xx-large"
 				}


### PR DESCRIPTION
This fixes following:

* update fluid typography
* fix typography for comments blocks

| Before | After |
| --- | --- |
| <img width="693" alt="image" src="https://user-images.githubusercontent.com/1935113/191920283-94551395-d302-47cc-806d-33c241af1d4b.png"> | <img width="693" alt="image" src="https://user-images.githubusercontent.com/1935113/191920416-ab70ee05-f692-45f4-8039-5a3b77d972b6.png"> |

* update font-size of navigation
* update casing for post-date

Fixes: #194 