### PR TITLE
Update Pilgrimage style varation: colors, gradients

### DIFF
--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -115,6 +115,11 @@
 					}
 				}
 			},
+			"core/image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
 			"core/navigation": {
 				"elements": {
 					"link": {
@@ -165,6 +170,11 @@
 					}
 				}
 			},
+			"core/post-featured-image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
 			"core/post-title": {
 				"elements": {
 					"link": {
@@ -193,7 +203,7 @@
 			},
 			"core/separator": {
 				"color": {
-					"text": "var(--wp--preset--color--tertiary)"
+					"text": "var(--wp--preset--color--secondary)"
 				}
 			},
 			"core/site-title": {

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -24,6 +24,16 @@
 					"slug": "secondary-primary"
 				},
 				{
+					"gradient": "linear-gradient(180deg, var(--wp--preset--color--primary) 0%,var(--wp--preset--color--tertiary) 100%)",
+					"name": "Tertiary to Secondary",
+					"slug": "tertiary-secondary"
+				},
+				{
+					"gradient": "linear-gradient(180deg, var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--primary) 100%)",
+					"name": "Tertiary to Primary",
+					"slug": "tertiary-primary"
+				},
+				{
 					"gradient": "linear-gradient(180deg, var(--wp--preset--color--base) 0%,var(--wp--preset--color--primary) 350%)",
 					"name": "Base to Primary",
 					"slug": "base-primary"
@@ -65,7 +75,7 @@
 					"link": {
 						":active": {
 							"color": {
-								"text": "var(--wp--preset--color--primary)"
+								"text": "var(--wp--preset--color--tertiary)"
 							}
 						}
 					}
@@ -76,7 +86,7 @@
 					"link": {
 						":active": {
 							"color": {
-								"text": "var(--wp--preset--color--primary)"
+								"text": "var(--wp--preset--color--tertiary)"
 							},
 							"typography": {
 								"textDecoration": "underline"
@@ -90,7 +100,7 @@
 					"link": {
 						":active": {
 							"color": {
-								"text": "var(--wp--preset--color--primary)"
+								"text": "var(--wp--preset--color--tertiary)"
 							}
 						}
 					}
@@ -103,11 +113,6 @@
 							"textDecoration": "underline"
 						}
 					}
-				}
-			},
-			"core/image": {
-				"filter": {
-					"duotone": "var(--wp--preset--duotone--default-filter)"
 				}
 			},
 			"core/navigation": {
@@ -135,11 +140,8 @@
 					"link": {
 						":hover": {
 							"color": {
-								"text": "var(--wp--preset--color--primary)"
+								"text": "var(--wp--preset--color--tertiary)"
 							}
-						},
-						"color": {
-							"text": "var(--wp--preset--color--primary)"
 						}
 					}
 				}
@@ -168,7 +170,7 @@
 					"link": {
 						":active": {
 							"color": {
-								"text": "var(--wp--preset--color--primary)"
+								"text": "var(--wp--preset--color--tertiary)"
 							},
 							"typography": {
 								"textDecoration": "underline"
@@ -191,7 +193,7 @@
 			},
 			"core/separator": {
 				"color": {
-					"text": "var(--wp--preset--color--primary)"
+					"text": "var(--wp--preset--color--tertiary)"
 				}
 			},
 			"core/site-title": {
@@ -205,9 +207,6 @@
 					}
 				}
 			}
-		},
-		"color": {
-			"gradient": "var(--wp--preset--gradient--base-primary)"
 		},
 		"elements": {
 			"button": {
@@ -270,18 +269,23 @@
 				}
 			},
 			"link": {
-				":active": {
-					"color": {
-						"text": "var(--wp--preset--color--primary)"
-					}
+				"color": {
+					"text": "var(--wp--preset--color--primary)"
 				},
 				":hover": {
 					"color": {
-						"text":"var(--wp--preset--color--primary)"
+						"text":"var(--wp--preset--color--tertiary)"
 					}
 				},
-				"color": {
-					"text": "var(--wp--preset--color--primary)"
+				":focus": {
+					"color": {
+						"text":"var(--wp--preset--color--tertiary)"
+					}
+				},
+				":active": {
+					"color": {
+						"text": "var(--wp--preset--color--tertiary)"
+					}
 				}
 			}
 		}

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -37,6 +37,11 @@
 					"gradient": "linear-gradient(180deg, var(--wp--preset--color--base) 0%,var(--wp--preset--color--primary) 350%)",
 					"name": "Base to Primary",
 					"slug": "base-primary"
+				},
+				{
+					"gradient": "radial-gradient(circle at 5px 5px,#0c0d0d70 1px,#ffffff00 3px,#ffffff00 2px) 0 0 / 8px 8px, linear-gradient(180deg, var(--wp--preset--color--base) 0%,#000000 200%)",
+					"name": "Dots",
+					"slug": "dots"
 				}
 			],
 			"palette": [
@@ -217,6 +222,9 @@
 					}
 				}
 			}
+		},
+		"color": {
+			"gradient": "var(--wp--preset--gradient--dots)"
 		},
 		"elements": {
 			"button": {

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -39,7 +39,7 @@
 					"slug": "base-primary"
 				},
 				{
-					"gradient": "radial-gradient(circle at 5px 5px,#0c0d0d70 1px,#ffffff00 3px,#ffffff00 2px) 0 0 / 8px 8px, linear-gradient(180deg, var(--wp--preset--color--base) 0%,#000000 200%)",
+					"gradient": "radial-gradient(circle at 5px 5px,#0c0d0d70 2px,#ffffff00 0px,#ffffff00 0px) 0 0 / 8px 8px, linear-gradient(180deg, var(--wp--preset--color--base) 0%,#000000 200%)",
 					"name": "Dots",
 					"slug": "dots"
 				}


### PR DESCRIPTION
I've updated the style variation to add the green to yellow gradients, as well as update some colors to make use of the tertiary color, that was otherwise not really added before. 

I've also removed the background gradient from the site, because I think it will be an issue with the green link colors at the footer with not having enough contrast for readability. I did not add the dotted background from the updated Figma design as I couldn't find a link to this document, but I think the variation works nicely without.

One thing I noticed is that my design is not going to work entirely, as the image block (in the home template at the top) does not have the gradient overlay functionality. I guess converting to a Cover block is not a solution here? I've asked the question already in Slack.

Let me know if we need to adjust anything else.