### PR TITLE
Remove "format" attribute from post-date blocks

### DIFF
--- a/patterns/post-meta.php
+++ b/patterns/post-meta.php
@@ -29,7 +29,7 @@
 				</p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:post-date {"format":"<?php echo esc_html_x( 'F j, Y', 'Date format for publication date of post', 'twentytwentythree' ); ?>"} /-->
+				<!-- wp:post-date /-->
 
 				<!-- wp:paragraph -->
 				<p>

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -10,7 +10,7 @@
 			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
-			<!-- wp:post-date {"format":"<?php echo get_option( 'date_format' ); ?>","isLink":true} /-->
+			<!-- wp:post-date {"isLink":true} /-->
 
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--50)"} -->
 			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -10,7 +10,7 @@
 			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
-			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
+			<!-- wp:post-date {"format":"<?php echo get_option( 'date_format' ); ?>","isLink":true} /-->
 
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--50)"} -->
 			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -17,7 +17,7 @@
 			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 			<!-- wp:post-title {"level":3,"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
-			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
+			<!-- wp:post-date {"isLink":true} /-->
 
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
 			<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true,"align":"wide"} /-->
 			<!-- wp:post-excerpt /-->
-			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
+			<!-- wp:post-date {"isLink":true} /-->
 
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} -->
 			<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -10,7 +10,7 @@
 			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
-			<!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
+			<!-- wp:post-date {"isLink":true} /-->
 
 			<!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} -->
 			<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
This is a suggestion to close #167

Instead of removing only the translation function, this PR completely removes the format attribute from the post-date blocks so WordPress will fall back to the Date Format set in the Settings Page. Users will still be able to change the format per template.