### PR TITLE
Update required WordPress version in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To get started with development:
 ## Requirements
 
 - Gutenberg plugin (latest)
-- WordPress 5.9+
+- WordPress 6.1+
 - PHP 5.6+
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html) or later
 


### PR DESCRIPTION
This PR updates the required WordPress version in the main readme, in line with recent changes to the WordPress version listed in style.css and readme.txt.

Closes https://github.com/WordPress/twentytwentythree/issues/207.