### PR TITLE
Update spacing preset names to use numbers

### DIFF
--- a/styles/marigold.json
+++ b/styles/marigold.json
@@ -38,32 +38,32 @@
 	  "spacingSizes": [
 		{
 		  "size": "clamp(0.625rem, 0.434rem + 0.61vw, 0.938rem)",
-		  "name": "30",
+		  "name": "1",
 		  "slug": "30"
 		},
 		{
 		  "size": "clamp(1.25rem, 0.869rem + 1.22vw, 1.875rem)",
-		  "name": "40",
+		  "name": "2",
 		  "slug": "40"
 		},
 		{
 		  "size": "clamp(1.875rem, 1.303rem + 1.83vw, 2.813rem)",
-		  "name": "50",
+		  "name": "3",
 		  "slug": "50"
 		},
 		{
 		  "size": "clamp(2.5rem, 1.738rem + 2.44vw, 3.75rem)",
-		  "name": "60",
+		  "name": "4",
 		  "slug": "60"
 		},
 		{
 		  "size": "clamp(2.813rem, 1.098rem + 5.49vw, 5.625rem)",
-		  "name": "70",
+		  "name": "5",
 		  "slug": "70"
 		},
 		{
 		  "size": "clamp(3.75rem, 1.463rem + 7.32vw, 7.5rem)",
-		  "name": "80",
+		  "name": "6",
 		  "slug": "80"
 		}
 	  ]

--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -42,37 +42,37 @@
 				{
 					"size": "calc(8px + 1.5625vw)",
 					"slug": "20",
-					"name": "Tiny"
+					"name": "1"
 				},
 				{
 					"size": "calc(12px + 1.5625vw)",
 					"slug": "30",
-					"name": "Small"
+					"name": "2"
 				},
 				{
 					"size": "calc(16px + 1.5625vw)",
 					"slug": "40",
-					"name": "Medium"
+					"name": "3"
 				},
 				{
 					"size": "calc(20px + 1.5625vw)",
 					"slug": "50",
-					"name": "Large"
+					"name": "4"
 				},
 				{
 					"size": "calc(24px + 1.5625vw)",
 					"slug": "60",
-					"name": "Extra Large"
+					"name": "5"
 				},
 				{
 					"size": "calc(28px + 1.5625vw)",
 					"slug": "70",
-					"name": "2X Large"
+					"name": "6"
 				},
 				{
 					"size": "calc(32px + 1.5625vw)",
 					"slug": "80",
-					"name": "3X Large"
+					"name": "7"
 				}
 			]
 		},

--- a/theme.json
+++ b/theme.json
@@ -84,32 +84,32 @@
 				{
 					"size": "clamp(1.5rem, 5vw, 2rem)",
 					"slug": "30",
-					"name": "30"
+					"name": "1"
 				},
 				{
 					"size": "clamp(1.8rem, 1.8rem + ((1vw - 0.48rem) * 2.885), 3rem)",
 					"slug": "40",
-					"name": "40"
+					"name": "2"
 				},
 				{
 					"size": "clamp(2.5rem, 8vw, 6.5rem)",
 					"slug": "50",
-					"name": "50"
+					"name": "3"
 				},
 				{
 					"size": "clamp(3.75rem, 10vw, 7rem)",
 					"slug": "60",
-					"name": "60"
+					"name": "4"
 				},
 				{
 					"size": "clamp(5rem, 5.25rem + ((1vw - 0.48rem) * 9.096), 8rem)",
 					"slug": "70",
-					"name": "70"
+					"name": "5"
 				},
 				{
 					"size": "clamp(7rem, 14vw, 11rem)",
 					"slug": "80",
-					"name": "80"
+					"name": "6"
 				}
 			],
 			"units": [


### PR DESCRIPTION
This PR updates all spacing preset names to the same number format, in line with recent changes in Gutenberg: https://github.com/WordPress/gutenberg/issues/43412 & https://github.com/WordPress/gutenberg/pull/44247