### PR TITLE
Allow no results block content to be translatable

### DIFF
--- a/patterns/hidden-no-results.php
+++ b/patterns/hidden-no-results.php
@@ -11,4 +11,4 @@
 </p>
 <!-- /wp:paragraph -->
 
-<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'label', 'twentytwentythree' ); ?>","placeholder":"<?php echo esc_html_x( 'Search...', 'placeholder for search field', 'twentytwentythree' ); ?>","showLabel":false,"buttonText":"<?php esc_html_e( 'Search', 'twentytwentythree' ); ?>","buttonUseIcon":true} /-->
+<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'label', 'twentytwentythree' ); ?>","placeholder":"<?php echo esc_attr_x( 'Search...', 'placeholder for search field', 'twentytwentythree' ); ?>","showLabel":false,"buttonText":"<?php esc_attr_e( 'Search', 'twentytwentythree' ); ?>","buttonUseIcon":true} /-->

--- a/patterns/hidden-no-results.php
+++ b/patterns/hidden-no-results.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Title: Hidden No Results Content
+ * Slug: twentytwentythree/hidden-no-results-content
+ * Inserter: no
+ */
+?>
+<!-- wp:paragraph -->
+<p>
+<?php echo esc_html_x( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentythree' ); ?>
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'label', 'twentytwentythree' ); ?>","placeholder":"<?php echo esc_html_x( 'Search...', 'placeholder for search field', 'twentytwentythree' ); ?>","showLabel":false,"buttonText":"<?php esc_html_e( 'Search', 'twentytwentythree' ); ?>","buttonUseIcon":true} /-->

--- a/templates/search.html
+++ b/templates/search.html
@@ -27,11 +27,7 @@
 		<!-- /wp:query-pagination -->
 
 		<!-- wp:query-no-results -->
-			<!-- wp:paragraph -->
-			<p>Sorry, but nothing matched your search terms. Please try again with some different keywords.</p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonUseIcon":true} /-->
+			<!-- wp:pattern {"slug":"twentytwentythree/hidden-no-results-content"} /-->
 		<!-- /wp:query-no-results -->
 	</div>
 	<!-- /wp:query -->


### PR DESCRIPTION
This PR adds a pattern for the `query-no-results` block content to make it translatable.

Fixes https://github.com/WordPress/twentytwentythree/issues/217.