### PR TITLE
Variation Canary: added hover state on button 

### DIFF
--- a/styles/canary.json
+++ b/styles/canary.json
@@ -131,8 +131,22 @@
 		},
 		"elements": {
 			"button": {
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--base)",
+						"text": "var(--wp--preset--color--contrast)"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--contrast)",
+						"style": "solid",
+						"width": "2px"
+					}
+				},
 				"border": {
-					"radius": "5px"
+					"radius": "5px",
+					"color": "var(--wp--preset--color--contrast)",
+					"style": "solid",
+					"width": "2px"
 				},
 				"color": {
 					"text": "var(--wp--preset--color--base)"


### PR DESCRIPTION
Issue: #182 

Fixed - Canary: button hover state is missing

Made the button design outline in hover state. Also, added a border around the button in default state so that it won't shift the contents around when the border is added on hover state. 