### PR TITLE
Remove empty image from home template

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -2,9 +2,6 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
-
-	<!-- wp:post-featured-image {"align":"wide"} /-->
-
 	<!-- wp:heading {"level":1,"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}}} -->
 	<h1 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--50)">Mindblown: a blog about philosophy.</h1>
 	<!-- /wp:heading -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,9 +3,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 
-	<!-- wp:image {"align":"wide"} -->
-	<figure class="wp-block-image alignwide"><img alt=""/></figure>
-	<!-- /wp:image -->
+	<!-- wp:post-featured-image {"align":"wide"} /-->
 
 	<!-- wp:heading {"level":1,"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}}} -->
 	<h1 class="alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--50)">Mindblown: a blog about philosophy.</h1>


### PR DESCRIPTION
This PR swaps the empty image included on the home template for a featured image block.

Fixes https://github.com/WordPress/twentytwentythree/issues/223.