### PR TITLE
Block out: Fix colour contrast on active buttons

### DIFF
--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -170,6 +170,11 @@
 					"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)",
 					"fontStyle": "italic",
 					"fontWeight": "400"
+				},
+				":active": {
+					"color": {
+						"text": "var(--wp--preset--color--contrast)"
+					}
 				}
 			},
 			"h1": {


### PR DESCRIPTION
This updates the text colour for the active state of buttons in Block out.

Part of https://github.com/WordPress/twentytwentythree/issues/182.