### PR TITLE
Electric: Add styles for active and focus button states

### DIFF
--- a/styles/electric.json
+++ b/styles/electric.json
@@ -51,6 +51,16 @@
 						"left": "1.333em"
 					}
 				},
+				":active": {
+					"typography": {
+						"textDecoration": "underline dotted"
+					}
+				},
+				":focus": {
+					"typography": {
+						"textDecoration": "underline dotted"
+					}
+				},
 				":hover": {
 					"border": {
 						"color": "var(--wp--preset--color--contrast)",


### PR DESCRIPTION
This updates the active and focus states for buttons in Electric.

Part of https://github.com/WordPress/twentytwentythree/issues/182.