### PR TITLE
Grapes: Make link hover state different to default state

### DIFF
--- a/styles/grapes.json
+++ b/styles/grapes.json
@@ -33,6 +33,17 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/post-comments": {
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						}
+					}
+				}
+			},
 			"core/post-date": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",

--- a/styles/grapes.json
+++ b/styles/grapes.json
@@ -65,7 +65,7 @@
 			"link": {
 				":hover": {
 					"typography": {
-						"textDecoration": "underline"
+						"textDecoration": "underline dashed"
 					}
 				}
 			}


### PR DESCRIPTION
This updates the link hover state for Grapes, so it's different from the default link state.

Part of https://github.com/WordPress/twentytwentythree/issues/182.