### PR TITLE
Pilgrimage: Fix button active state

### DIFF
--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -213,7 +213,8 @@
 			"button": {
 				":active": {
 					"color": {
-						"background": "var(--wp--preset--color--secondary)"
+						"background": "var(--wp--preset--color--secondary)",
+						"gradient": "none"
 					}
 				},
 				":focus": {


### PR DESCRIPTION
This updates the button active state for Pilgrimage, by deactivating the gradient in favour of the background colour.

Part of https://github.com/WordPress/twentytwentythree/issues/182.