### PR TITLE
Pitch: Update button pseudo-state colours

### DIFF
--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -168,19 +168,19 @@
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
-						"text": "var(--wp--preset--color--primary)"
+						"text": "var(--wp--preset--color--tertiary)"
 					}
 				},
 				":focus": {
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
-						"text": "var(--wp--preset--color--primary)"
+						"text": "var(--wp--preset--color--tertiary)"
 					}
 				},
 				":active": {
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
-						"text": "var(--wp--preset--color--primary)"
+						"text": "var(--wp--preset--color--tertiary)"
 					}
 				}
 			},


### PR DESCRIPTION
This updates the text colour of the buttons in Pitch, for their active, focus and hover states. This makes the text easier to read in each state.

Part of https://github.com/WordPress/twentytwentythree/issues/182.