### PR TITLE
Add hover state to Query Pagination and Post Date links

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -478,31 +478,6 @@
 			"core/comment-edit-link": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
-				},
-				"elements": {
-					"link": {
-						":hover": {
-							"typography": {
-								"textDecoration": "underline"
-							}
-						},
-						":focus": {
-							"typography": {
-								"textDecoration": "underline dashed"
-							}
-						},
-						":active": {
-							"color": {
-								"text": "var(--wp--preset--color--secondary)"
-							},
-							"typography": {
-								"textDecoration": "none"
-							}
-						},
-						"typography": {
-							"textDecoration": "none"
-						}
-					}
 				}
 			},
 			"core/comment-reply-link": {

--- a/theme.json
+++ b/theme.json
@@ -358,6 +358,11 @@
 					"link": {
 						"typography": {
 							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				}
@@ -533,6 +538,11 @@
 					"link": {
 						"typography": {
 							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This updates the hover state of the links in Query Pagination and Post Date blocks.

Also tested that the pseudo-state styles work with Query Pagination numbers.

Part of https://github.com/WordPress/twentytwentythree/issues/182.