### PR TITLE
Swap post-author-name for post-author block

### DIFF
--- a/patterns/post-meta.php
+++ b/patterns/post-meta.php
@@ -49,7 +49,7 @@
 				</p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:post-author-name {"isLink":true} /-->
+				<!-- wp:post-author {"showAvatar":false} /-->
 			</div>
 			<!-- /wp:group -->
 		</div>

--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -115,16 +115,12 @@
 					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
-			"core/post-author-name": {
-				"elements": {
-					"link": {
-						"color": {
-							"text": "var(--wp--preset--color--primary)"
-						},
-						"typography": {
-							"fontStyle": "italic"
-						}
-					}
+			"core/post-author": {
+				"color": {
+					"text": "var(--wp--preset--color--primary)"
+				},
+				"typography": {
+					"fontStyle": "italic"
 				}
 			},
 			"core/post-content": {


### PR DESCRIPTION
This fixes upstream change noted here: https://github.com/WordPress/gutenberg/issues/44618

![Screen Shot 2022-09-30 at 2 39 40 PM](https://user-images.githubusercontent.com/405912/193335624-9845f9f5-0bcf-425a-ae63-f822e465b08b.png)

![Screen Shot 2022-09-30 at 2 39 56 PM](https://user-images.githubusercontent.com/405912/193335644-31545d9d-4a44-42f9-ba82-04429335f6a6.png)
