### PR TITLE
fix buttion size differences for pitch style variation

### DIFF
--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -145,7 +145,10 @@
 		"elements": {
 			"button": {
 				"border": {
-					"radius": "0"
+					"radius": "0",
+					"style": "solid",
+					"width": "2px",
+					"color": "var(--wp--preset--color--primary)"
 				},
 				"color": {
 					"background": "var(--wp--preset--color--primary)",
@@ -153,10 +156,10 @@
 				},
 				"spacing": {
 					"padding": {
-						"top": "min(1.25rem, 3vw)",
-						"right": "min(2.25rem, 5vw)",
-						"bottom": "min(1.25rem, 3vw)",
-						"left": "min(2.25rem, 5vw)"
+						"top": "min(1.125rem, 3vw) !important",
+						"right": "min(2.125rem, 5vw) !important",
+						"bottom": "min(1.125rem, 3vw) !important",
+						"left": "min(2.125rem, 5vw) !important"
 					}
 				},
 				"typography": {
@@ -166,18 +169,27 @@
 					"letterSpacing": "0.01em"
 				},
 				":hover": {
+					"border": {
+						"color": "var(--wp--preset--color--contrast)"
+					},
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
 						"text": "var(--wp--preset--color--tertiary)"
 					}
 				},
 				":focus": {
+					"border": {
+						"color": "var(--wp--preset--color--contrast)"
+					},
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
 						"text": "var(--wp--preset--color--tertiary)"
 					}
 				},
 				":active": {
+					"border": {
+						"color": "var(--wp--preset--color--contrast)"
+					},
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
 						"text": "var(--wp--preset--color--tertiary)"


### PR DESCRIPTION
This fixes the outline button size by adding higher specificity for padding.

<img width="464" alt="image" src="https://user-images.githubusercontent.com/1935113/193544644-09ceccab-5a32-4d5b-b3a2-ccf5a348669c.png">

Still the button sizes doesn't match by `2px` because of the border.
To counter, reduced padding by 2px and introduced a border same as background color.

Fixes: #216 