### PR TITLE
Improve block spacing in post meta elements

### DIFF
--- a/patterns/post-meta.php
+++ b/patterns/post-meta.php
@@ -21,7 +21,7 @@
 	<div class="wp-block-columns alignwide has-small-font-size" style="margin-top:var(--wp--preset--spacing--40)">
 		<!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 		<div class="wp-block-column">
-			<!-- wp:group {"style":{"spacing":{"blockGap":"1ch"}},"layout":{"type":"flex"}} -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0.5ch"}},"layout":{"type":"flex"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph -->
 				<p>
@@ -41,7 +41,7 @@
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:group {"style":{"spacing":{"blockGap":"1ch"}},"layout":{"type":"flex"}} -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0.5ch"}},"layout":{"type":"flex"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph -->
 				<p>
@@ -57,7 +57,7 @@
 
 		<!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 		<div class="wp-block-column">
-			<!-- wp:group {"style":{"spacing":{"blockGap":"1ch"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0.5ch"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph -->
 				<p>


### PR DESCRIPTION
This PR slightly reduces the block spacing of child elements in the post meta pattern, from 1ch to 0.5ch.

I tried removing the blockGap size altogether, but this meant it inherited the parent block spacing which is much larger. I then tried setting the block spacing on each nested element to 0px, but this meant all the elements had no spacing at all. Reducing the existing spacing seemed like the best option.

Closes https://github.com/WordPress/twentytwentythree/issues/238.