### PR TITLE
Readme: Replace PHP 5.7 with 5.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
This changeset replace "PHP 5.7" with "PHP 5.6" in TT3's readme, since PHP 5.7 never existed :)