### PR TITLE
Update copyright years

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ https://wordpress.org/support/article/twenty-twenty-three-changelog#Version_1.0
 
 == Copyright ==
 
-Twenty Twenty-Three WordPress Theme, (C) 2022 wordpressdotorg
+Twenty Twenty-Three WordPress Theme, (C) 2022-2023 WordPress.org
 Twenty Twenty-Three is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
This updates readme.txt copyright years to make it consistent with other bundled themes.
See TT2: https://github.com/WordPress/twentytwentytwo/blob/trunk/readme.txt

It also replaces "wordpressdotorg" with "WordPress.org" in the same copyright section, to make it consistent with previous bundled themes as well.