### PR TITLE
Prepare for Theme Repository: add `Stable tag` declaration.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: wordpressdotorg
 Requires at least: 6.1
 Tested up to: 6.1
 Requires PHP: 5.6
+Stable tag: 1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
This changeset adds `Stable tag` declaration and sets it to `1.0` in the `readme.txt` file.
It is necessary to indicate which version is the stable tag to use.

We don't need to add this mention in `style.css`, only on `readme.txt`.