### PR TITLE
Blog (Alternative) Template: remove inherit from the query

### DIFF
--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -4,7 +4,7 @@
 <main class="wp-block-group">
 	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /-->
 
-	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
+	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template -->
 			<!-- wp:group {"style":{"border":{"top":{"width":"1px"},"right":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->


### PR DESCRIPTION
When `inherit: true` is set on the query loop in the template, the template only shows the page that the template is assigned to.
The PR sets inherit to false, so that the latest 3 posts are displayed.

Closes
https://github.com/WordPress/twentytwentythree/issues/253
