### PR TITLE
Blog (Alternative) Template: Add links to the post titles in the query

### DIFF
--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -10,7 +10,7 @@
 			<!-- wp:group {"style":{"border":{"top":{"width":"1px"},"right":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 			<div class="wp-block-group" style="border-top-width:1px;border-right-style:none;border-right-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 				<!-- wp:post-date /-->
-				<!-- wp:post-title /-->
+				<!-- wp:post-title {"isLink":true} /-->
 			</div>
 			<!-- /wp:group -->
 		<!-- /wp:post-template -->


### PR DESCRIPTION
This PR adds links to the post titles in the query, so that the posts can be opened.
Closes https://github.com/WordPress/twentytwentythree/issues/256