### PR TITLE
Try:  Add border to query pagination

### DIFF
--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -180,6 +180,13 @@
 					}
 				}
 			},
+			"core/query-pagination": {
+				"border": {
+					"top": {
+						"color": "var(--wp--preset--color--primary)"
+					}
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--preset--color--primary)"

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -117,6 +117,13 @@
 					"fontWeight": "700"
 				}
 			},
+			"core/query-pagination": {
+				"border": {
+					"top": {
+						"width": "4px"
+					}
+				}
+			},
 			"core/separator": {
 				"border": {
 					"width": "2px"

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -187,6 +187,11 @@
 							"textDecoration": "underline"
 						}
 					}
+				},
+				"border": {
+					"top": {
+						"color": "var(--wp--preset--color--primary)"
+					}
 				}
 			},
 			"core/separator": {

--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -128,6 +128,14 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/query-pagination": {
+				"border": {
+					"top": {
+						"color": "var(--wp--preset--color--tertiary)",
+						"width": "4px"
+					}
+				}
+			},
 			"core/separator": {
 				"border": {
 					"color":"var(--wp--preset--color--tertiary)",

--- a/styles/whisper.json
+++ b/styles/whisper.json
@@ -202,6 +202,15 @@
 					}
 				}
 			},
+			"core/query-pagination": {
+				"border": {
+					"top": {
+						"color": "var(--wp--preset--color--contrast)",
+						"style": "double",
+						"width": "6px"
+					}
+				}
+			},
 			"core/separator": {
 				"border": {
 					"color": "var(--wp--preset--color--contrast)",

--- a/templates/home.html
+++ b/templates/home.html
@@ -19,10 +19,6 @@
 			<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 
-		<!-- wp:separator {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
-		<hr class="wp-block-separator alignwide has-alpha-channel-opacity" style="margin-bottom:var(--wp--preset--spacing--40)"/>
-		<!-- /wp:separator -->
-
 		<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->

--- a/theme.json
+++ b/theme.json
@@ -496,6 +496,17 @@
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": "400"
 				},
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--preset--spacing--40)"
+					}
+				},
+				"border": {
+					"top": {
+						"width": "2px",
+						"style": "solid"
+					}
+				},
 				"elements": {
 					"link": {
 						"typography": {


### PR DESCRIPTION
This is a test where the separator above the query pagination on the home template is removed and replaced with a border. The border and spacing is added to theme.json.

-The border should only be visible if there is a result to paginate through.
You can test this by setting _Reading > Blog pages show at most_ to a number that is higher than the number of posts on  your install.

Downside: The user can't edit or remove the border without editing theme.json.
Upside: Style variations can decide to use a border or not.

Closes https://github.com/WordPress/twentytwentythree/issues/205