### PR TITLE
Canary: Add underlines to links in post content and comment content

### DIFF
--- a/styles/canary.json
+++ b/styles/canary.json
@@ -70,7 +70,7 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/comment-content": {
+			"core/comments": {
 				"elements": {
 					"link": {
 						"typography": {

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -70,6 +70,20 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/comment-content": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "underline"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "none"
+							}
+						}
+					}
+				}
+			},
 			"core/comment-reply-link": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -91,6 +105,20 @@
 			"core/navigation": {
 				"typography": {
 					"textTransform": "lowercase"
+				}
+			},
+			"core/post-content": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "underline"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "none"
+							}
+						}
+					}
 				}
 			},
 			"core/post-featured-image": {


### PR DESCRIPTION
Adds underlines to links in post content and comment content blocks. With this PR:

- Default state: solid underline
- Hover: no underline
- Active: no underline
- Focus: dashed underline



Partial for [218.](https://github.com/WordPress/twentytwentythree/issues/218)