### PR TITLE
Block Out variation: Reduce XXL font size

### DIFF
--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -73,10 +73,10 @@
 				},
 				{
 					"fluid": {
-						"max": "14rem",
+						"max": "7rem",
 						"min": "4rem"
 					},
-					"size": "10rem",
+					"size": "7rem",
 					"slug": "xx-large"
 				}
 			]

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -145,6 +145,12 @@
 				}
 			},
 			"core/site-title": {
+				"spacing": {
+					"padding": {
+						"bottom": "var(--wp--preset--spacing--30)",
+						"top": "var(--wp--preset--spacing--30)"
+					}
+				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"lineHeight": "1.1",

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -159,9 +159,9 @@
 			},
 			"core/query": {
 				"elements": {
-					"h3": {
-						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+					"h2": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--large)"
 						}
 					}
 				}


### PR DESCRIPTION
This reduces the XXL font size preset in the Block Out variation by around 50%, as discussed [here](https://github.com/WordPress/twentytwentythree/issues/251).

These are before/afters of the maximum size on my screen, at the same browser resolution:

Header:

| Before | After |
| ------ | ----- |
| <img width="1080" alt="image" src="https://user-images.githubusercontent.com/1645628/194300457-19b3e378-7011-4200-800f-44a9813a36a8.png"> | <img width="1080" alt="image" src="https://user-images.githubusercontent.com/1645628/194300349-a209193b-5d36-4eb0-a887-925e3700bb82.png"> |

Footer:

| Before | After |
| ------ | ----- |
| <img width="1080" alt="image" src="https://user-images.githubusercontent.com/1645628/194300729-8db172ef-55b5-4f60-a7c2-5d8db45f2ab0.png"> | <img width="1080" alt="image" src="https://user-images.githubusercontent.com/1645628/194300872-1e5d4615-df7a-41fd-be92-c11173965544.png"> |


Closes https://github.com/WordPress/twentytwentythree/issues/251.

cc. @kathrynwp