### PR TITLE
Base theme: Set all link underlines to 1px

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -295,12 +295,12 @@
 					"link": {
 						":hover": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline 1px"
 							}
 						},
 						":focus": {
 							"typography": {
-								"textDecoration": "underline dashed"
+								"textDecoration": "underline 1px dashed"
 							}
 						},
 						":active": {
@@ -348,7 +348,7 @@
 						},
 						":hover": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline 1px"
 							}
 						}
 					}
@@ -373,12 +373,12 @@
 					"link": {
 						":hover": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline 1px"
 							}
 						},
 						":focus": {
 							"typography": {
-								"textDecoration": "underline dashed"
+								"textDecoration": "underline 1px dashed"
 							}
 						},
 						":active": {
@@ -410,12 +410,12 @@
 					"link": {
 						":hover": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline 1px"
 							}
 						},
 						":focus": {
 							"typography": {
-								"textDecoration": "underline dashed"
+								"textDecoration": "underline 1px dashed"
 							}
 						},
 						":active": {
@@ -440,12 +440,12 @@
 					"link": {
 						":hover": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline 1px"
 							}
 						},
 						":focus": {
 							"typography": {
-								"textDecoration": "underline dashed"
+								"textDecoration": "underline 1px dashed"
 							}
 						},
 						":active": {
@@ -503,7 +503,7 @@
 						},
 						":hover": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline 1px"
 							}
 						}
 					}
@@ -519,12 +519,12 @@
 					"link": {
 						":hover": {
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline 1px"
 							}
 						},
 						":focus": {
 							"typography": {
-								"textDecoration": "underline dashed"
+								"textDecoration": "underline 1px dashed"
 							}
 						},
 						":active": {
@@ -631,7 +631,7 @@
 				},
 				":focus": {
 					"typography": {
-						"textDecoration": "underline dashed"
+						"textDecoration": "underline 1px dashed"
 					}
 				},
 				":active": {
@@ -643,7 +643,7 @@
 					}
 				},
 				"typography": {
-					"textDecoration": "underline"
+					"textDecoration": "underline 1px"
 				}
 			}
 		},


### PR DESCRIPTION
This sets all link underlines on the base theme to 1px thickness.

I think this may be inherited by all the style variations, so if this is approved, we'll need to go through each variation and reset the line thickness in their JSON files.

Part of https://github.com/WordPress/twentytwentythree/issues/4.