### PR TITLE
Update Blog (Alternative) template

### DIFF
--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -5,8 +5,8 @@
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template -->
-			<!-- wp:group {"style":{"border":{"top":{"width":"1px"},"right":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group" style="border-top-width:1px;border-right-style:none;border-right-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+			<!-- wp:group {"style":{"border":{"bottom":{"width":"1px"},"right":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group" style="border-bottom-width:1px;border-right-style:none;border-right-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 				<!-- wp:post-date /-->
 				<!-- wp:post-title {"isLink":true} /-->
 			</div>

--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -5,12 +5,21 @@
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template -->
-			<!-- wp:group {"style":{"border":{"bottom":{"width":"1px"},"right":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group" style="border-bottom-width:1px;border-right-style:none;border-right-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-				<!-- wp:post-date /-->
-				<!-- wp:post-title {"isLink":true} /-->
+			<!-- wp:columns {"verticalAlignment":null,"style":{"border":{"bottom":{"width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} -->
+			<div class="wp-block-columns" style="border-bottom-width:1px;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+				<!-- wp:column {"verticalAlignment":"center","width":"20%"} -->
+				<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:20%">
+					<!-- wp:post-date {"textAlign":"left"} /-->
+				</div>
+				<!-- /wp:column -->
+
+				<!-- wp:column {"verticalAlignment":"center","width":"80%"} -->
+				<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:80%">
+					<!-- wp:post-title /-->
+				</div>
+				<!-- /wp:column -->
 			</div>
-			<!-- /wp:group -->
+			<!-- /wp:columns -->
 		<!-- /wp:post-template -->
 	</div>
 	<!-- /wp:query -->

--- a/templates/blog-alternative.html
+++ b/templates/blog-alternative.html
@@ -2,8 +2,6 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:post-author-biography {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /-->
-
 	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template -->


### PR DESCRIPTION
This removes the Post Author Biography from the Blog (Alternative) template, and moves the border in the post template from the top of the posts to the bottom.

It also swaps the row block for a columns block, as I noticed with my demo content that the posts didn't always align consistently.

| Before | After |
| ------ | ----- |
| ![local-test-site local_blog-alternative_ (1)](https://user-images.githubusercontent.com/1645628/194541585-f22e57ff-91a2-43a8-b520-f293f7faabe0.png) | ![local-test-site local_blog-alternative_](https://user-images.githubusercontent.com/1645628/194541385-af2f313f-fc29-4309-acf5-9b35bf690f4d.png) |

Closes https://github.com/WordPress/twentytwentythree/issues/252.

cc. @kathrynwp