### PR TITLE
Remove separators from archive and search templates

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -17,10 +17,6 @@
 			<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 
-		<!-- wp:separator {"style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--40)"}}}} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity" style="margin-bottom:var(--wp--preset--spacing--40)"/>
-		<!-- /wp:separator -->
-
 		<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
 			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->

--- a/templates/search.html
+++ b/templates/search.html
@@ -17,10 +17,6 @@
 			<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 
-		<!-- wp:separator {"style":{"spacing":{"margin":{"bottom":"var(--wp--preset--spacing--70)"}}}} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity" style="margin-bottom:var(--wp--preset--spacing--70)"/>
-		<!-- /wp:separator -->
-
 		<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
 			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->


### PR DESCRIPTION
Quick PR to remove the separators above the query pagination blocks on the archive and search templates.

Follow on from https://github.com/WordPress/twentytwentythree/pull/258.