### PR TITLE
Improve pullquote block styles

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -488,7 +488,18 @@
 			},
 			"core/pullquote": {
 				"border": {
+					"style": "solid",
 					"width": "1px 0"
+				},
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--small)"
+						}
+					}
+				},
+				"typography": {
+					"lineHeight": "1.3"
 				}
 			},
 			"core/query-pagination": {

--- a/theme.json
+++ b/theme.json
@@ -503,8 +503,8 @@
 				},
 				"spacing": {
 					"margin": {
-						"bottom": "var(--wp--preset--spacing--50) !important",
-						"top": "var(--wp--preset--spacing--50) !important"
+						"bottom": "var(--wp--preset--spacing--40) !important",
+						"top": "var(--wp--preset--spacing--40) !important"
 					}
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -550,6 +550,12 @@
 							"fontStyle": "normal"
 						}
 					}
+				},
+				"spacing": {
+					"padding": {
+						"left": "var(--wp--preset--spacing--30)",
+						"right": "var(--wp--preset--spacing--30)"
+					}
 				}
 			},
 			"core/site-title": {

--- a/theme.json
+++ b/theme.json
@@ -500,6 +500,12 @@
 				},
 				"typography": {
 					"lineHeight": "1.3"
+				},
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--preset--spacing--50) !important",
+						"top": "var(--wp--preset--spacing--50) !important"
+					}
 				}
 			},
 			"core/query-pagination": {

--- a/theme.json
+++ b/theme.json
@@ -494,7 +494,9 @@
 				"elements": {
 					"cite": {
 						"typography": {
-							"fontSize": "var(--wp--preset--font-size--small)"
+							"fontSize": "var(--wp--preset--font-size--small)",
+							"fontStyle": "normal",
+							"textTransform": "none"
 						}
 					}
 				},

--- a/theme.json
+++ b/theme.json
@@ -542,6 +542,14 @@
 			"core/quote": {
 				"border": {
 					"width": "1px"
+				},
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--small)",
+							"fontStyle": "normal"
+						}
+					}
 				}
 			},
 			"core/site-title": {


### PR DESCRIPTION
This PR improves the pullquote block styles:

- Applies small font size to citation
- Adds top and bottom border
- Applies 1.3 line-height
- Adds top and bottom margin using the `var(--wp--preset--spacing--40)` preset

<img width="706" alt="image" src="https://user-images.githubusercontent.com/1645628/194575593-49b842ac-d00e-4ec5-84ad-c14a3d225053.png">

Closes https://github.com/WordPress/twentytwentythree/issues/263.