### PR TITLE
Canary: Update buttons

### DIFF
--- a/styles/canary.json
+++ b/styles/canary.json
@@ -177,6 +177,17 @@
 						"width": "2px"
 					}
 				},
+				":focus": {
+					"color": {
+						"background": "var(--wp--preset--color--base)",
+						"text": "var(--wp--preset--color--contrast)"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--contrast)",
+						"style": "solid",
+						"width": "2px"
+					}
+				},
 				"border": {
 					"radius": "5px",
 					"color": "var(--wp--preset--color--contrast)",

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -196,6 +196,14 @@
 				},
 				"color": {
 					"text": "var(--wp--preset--color--base)"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "0.667em",
+						"left": "1.333em",
+						"right": "1.333em",
+						"top": "0.667em"
+					}
 				}
 			},
 			"h1": {


### PR DESCRIPTION
This makes the sizes of the default and outline buttons the same, and adds a focus button state.

Buttons the same size: 
<img width="277" alt="image" src="https://user-images.githubusercontent.com/1645628/194572516-d3cdfc66-f704-4040-85eb-6f3eca6b0c55.png">

Default focus state:
<img width="139" alt="image" src="https://user-images.githubusercontent.com/1645628/194572648-9991e67b-f272-435c-ad5e-7b7f73357ad3.png">

Closes https://github.com/WordPress/twentytwentythree/issues/247.