### PR TITLE
Reorder property and fix validation error in json files

### DIFF
--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -1,5 +1,6 @@
 {
-	"title": "Aubergine",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"settings": {
 		"color": {
 			"gradients": [
@@ -276,7 +277,5 @@
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--dm-sans)"
 		}
-	},
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	}
 }

--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Aubergine",
 	"settings": {
 		"color": {
 			"gradients": [

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -1,5 +1,6 @@
 {
-	"title": "Block out",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"settings": {
 		"color": {
 			"duotone": [
@@ -216,7 +217,5 @@
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--dm-sans)"
 		}
-	},
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	}
 }

--- a/styles/block-out.json
+++ b/styles/block-out.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Block out",
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Canary",
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -1,5 +1,6 @@
 {
-	"title": "Canary",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"settings": {
 		"color": {
 			"duotone": [
@@ -240,7 +241,5 @@
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)"
 		}
-	},
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	}
 }

--- a/styles/electric.json
+++ b/styles/electric.json
@@ -1,5 +1,6 @@
 {
-	"title": "Electric",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"settings": {
 		"color": {
 			"palette": [
@@ -89,7 +90,5 @@
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--dm-sans)"
 		}
-	},
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	}
 }

--- a/styles/electric.json
+++ b/styles/electric.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Electric",
 	"settings": {
 		"color": {
 			"palette": [

--- a/styles/grapes.json
+++ b/styles/grapes.json
@@ -1,5 +1,6 @@
 {
-	"title": "Grapes",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"settings": {
 		"color": {
 			"palette": [
@@ -86,7 +87,5 @@
 				}
 			}
 		}
-	},
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	}
 }

--- a/styles/grapes.json
+++ b/styles/grapes.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Grapes",
 	"settings": {
 		"color": {
 			"palette": [

--- a/styles/marigold.json
+++ b/styles/marigold.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schemas.wp.org/trunk/theme.json",
   "version": 2,
+	"title": "Marigold",
   "settings": {
 		"color": {
 			"palette": [

--- a/styles/marigold.json
+++ b/styles/marigold.json
@@ -1,305 +1,299 @@
 {
   "$schema": "https://schemas.wp.org/trunk/theme.json",
-  "title": "Marigold",
+  "version": 2,
   "settings": {
-	"color": {
-	  "palette": [
-		{
-		  "color": "#F6F2EC",
-		  "name": "Base",
-		  "slug": "base"
+		"color": {
+			"palette": [
+				{
+					"color": "#F6F2EC",
+					"name": "Base",
+					"slug": "base"
+				},
+				{
+					"color": "#21251F",
+					"name": "Contrast",
+					"slug": "contrast"
+				},
+				{
+					"color": "#5B4460",
+					"name": "Primary",
+					"slug": "primary"
+				},
+				{
+					"color": "#FCC263",
+					"name": "Secondary",
+					"slug": "secondary"
+				},
+				{
+					"color": "#E7A1A9",
+					"name": "Tertiary",
+					"slug": "tertiary"
+				}
+			]
 		},
-		{
-		  "color": "#21251F",
-		  "name": "Contrast",
-		  "slug": "contrast"
+		"layout": {
+			"wideSize": "1200px"
 		},
-		{
-		  "color": "#5B4460",
-		  "name": "Primary",
-		  "slug": "primary"
+		"spacing": {
+			"spacingSizes": [
+				{
+					"size": "clamp(0.625rem, 0.434rem + 0.61vw, 0.938rem)",
+					"name": "1",
+					"slug": "30"
+				},
+				{
+					"size": "clamp(1.25rem, 0.869rem + 1.22vw, 1.875rem)",
+					"name": "2",
+					"slug": "40"
+				},
+				{
+					"size": "clamp(1.875rem, 1.303rem + 1.83vw, 2.813rem)",
+					"name": "3",
+					"slug": "50"
+				},
+				{
+					"size": "clamp(2.5rem, 1.738rem + 2.44vw, 3.75rem)",
+					"name": "4",
+					"slug": "60"
+				},
+				{
+					"size": "clamp(2.813rem, 1.098rem + 5.49vw, 5.625rem)",
+					"name": "5",
+					"slug": "70"
+				},
+				{
+					"size": "clamp(3.75rem, 1.463rem + 7.32vw, 7.5rem)",
+					"name": "6",
+					"slug": "80"
+				}
+			]
 		},
-		{
-		  "color": "#FCC263",
-		  "name": "Secondary",
-		  "slug": "secondary"
-		},
-		{
-		  "color": "#E7A1A9",
-		  "name": "Tertiary",
-		  "slug": "tertiary"
+		"typography": {
+			"fontSizes": [
+				{
+					"size": "clamp(0.875rem, 0.799rem + 0.24vw, 1rem)",
+					"name": "Tiny",
+					"slug": "tiny"
+				},
+				{
+					"size": "clamp(1rem, 0.924rem + 0.24vw, 1.125rem)",
+					"slug": "small"
+				},
+				{
+					"size": "clamp(1.125rem, 1.049rem + 0.24vw, 1.25rem)",
+					"name": "Normal",
+					"slug": "normal"
+				},
+				{
+					"size": "clamp(1.25rem, 1.021rem + 0.73vw, 1.625rem)",
+					"slug": "medium"
+				},
+				{
+					"size": "clamp(1.375rem, 1.07rem + 0.98vw, 1.875rem)",
+					"slug": "large"
+				},
+				{
+					"size": "clamp(1.75rem, 1.369rem + 1.22vw, 2.375rem)",
+					"slug": "x-large"
+				},
+				{
+					"size": "clamp(2.125rem, 1.706rem + 1.34vw, 2.813rem)",
+					"slug": "xx-large"
+				},
+				{
+					"size": "clamp(2.5rem, 1.966rem + 1.71vw, 3.375rem)",
+					"name": "Huge",
+					"slug": "huge"
+				},
+				{
+					"size": "clamp(3.375rem, 2.384rem + 3.17vw, 5rem)",
+					"name": "Gigantic",
+					"slug": "gigantic"
+				}
+			]
 		}
-	  ]
-	},
-	"layout": {
-	  "wideSize": "1200px"
-	},
-	"spacing": {
-	  "spacingSizes": [
-		{
-		  "size": "clamp(0.625rem, 0.434rem + 0.61vw, 0.938rem)",
-		  "name": "1",
-		  "slug": "30"
-		},
-		{
-		  "size": "clamp(1.25rem, 0.869rem + 1.22vw, 1.875rem)",
-		  "name": "2",
-		  "slug": "40"
-		},
-		{
-		  "size": "clamp(1.875rem, 1.303rem + 1.83vw, 2.813rem)",
-		  "name": "3",
-		  "slug": "50"
-		},
-		{
-		  "size": "clamp(2.5rem, 1.738rem + 2.44vw, 3.75rem)",
-		  "name": "4",
-		  "slug": "60"
-		},
-		{
-		  "size": "clamp(2.813rem, 1.098rem + 5.49vw, 5.625rem)",
-		  "name": "5",
-		  "slug": "70"
-		},
-		{
-		  "size": "clamp(3.75rem, 1.463rem + 7.32vw, 7.5rem)",
-		  "name": "6",
-		  "slug": "80"
-		}
-	  ]
-	},
-	"typography": {
-	  "fontSizes": [
-		{
-		  "size": "clamp(0.875rem, 0.799rem + 0.24vw, 1rem)",
-		  "name": "Tiny",
-		  "slug": "tiny"
-		},
-		{
-		  "size": "clamp(1rem, 0.924rem + 0.24vw, 1.125rem)",
-		  "slug": "small"
-		},
-		{
-		  "size": "clamp(1.125rem, 1.049rem + 0.24vw, 1.25rem)",
-		  "name": "Normal",
-		  "slug": "normal"
-		},
-		{
-		  "size": "clamp(1.25rem, 1.021rem + 0.73vw, 1.625rem)",
-		  "slug": "medium"
-		},
-		{
-		  "size": "clamp(1.375rem, 1.07rem + 0.98vw, 1.875rem)",
-		  "slug": "large"
-		},
-		{
-		  "size": "clamp(1.75rem, 1.369rem + 1.22vw, 2.375rem)",
-		  "slug": "x-large"
-		},
-		{
-		  "size": "clamp(2.125rem, 1.706rem + 1.34vw, 2.813rem)",
-		  "slug": "xx-large"
-		},
-		{
-		  "size": "clamp(2.5rem, 1.966rem + 1.71vw, 3.375rem)",
-		  "name": "Huge",
-		  "slug": "huge"
-		},
-		{
-		  "size": "clamp(3.375rem, 2.384rem + 3.17vw, 5rem)",
-		  "name": "Gigantic",
-		  "slug": "gigantic"
-		}
-	  ]
-	}
   },
   "styles": {
-	"blocks": {
-	  "core/query": {
-		"spacing": {
-		  "padding": {
-			"left": "0",
-			"right": "0"
-		  }
-		}
-	  },
-	  "core/post-content": {
-		"elements": {
-		  "link": {
-			"color": {
-			  "text": "var(--wp--preset--color--primary)"
-			}
-		  }
-		}
-	  },
-	  "core/post-excerpt": {
-		"typography": {
-		  "fontSize": "var(--wp--preset--font-size--normal)"
-		}
-	  },
-	  "core/post-title": {
-		"elements": {
-		  "link": {
-			"typography": {
-			  "fontSize": "var(--wp--preset--font-size--large)",
-			  "textDecoration": "none"
+		"blocks": {
+			"core/query": {
+				"spacing": {
+					"padding": {
+						"left": "0",
+						"right": "0"
+					}
+				}
 			},
-			"color": {
-			  "text": "var(--wp--preset--color--primary)"
+			"core/post-content": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--primary)"
+						}
+					}
+				}
 			},
-			":hover": {
-			  "border": {
-				"bottom": true
-			  }
+			"core/post-excerpt": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				}
+			},
+			"core/post-title": {
+				"elements": {
+					"link": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--large)",
+							"textDecoration": "none"
+						},
+						"color": {
+							"text": "var(--wp--preset--color--primary)"
+						}
+					}
+				},
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--preset--spacing--50)",
+						"top": "var(--wp--preset--spacing--50)"
+					}
+				},
+				"typography": {
+					"fontWeight": "600"
+				}
+			},
+			"core/pullquote": {
+				"border": {
+					"width": "1px 0"
+				}
+			},
+			"core/query-pagination": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "400"
+				}
+			},
+			"core/quote": {
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontSize": "1.25rem"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "1.625rem",
+					"lineHeight": "1.5"
+				}
+			},
+			"core/site-title": {
+				"elements": {
+					"link": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--normal)"
+						}
+					}
+				},
+				"typography": {
+					"textTransform": "lowercase"
+				}
 			}
-		  }
+		},
+		"elements": {
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--huge)",
+					"lineHeight": "1.1"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)",
+					"lineHeight": "1.2"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"lineHeight": "1.2"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "600"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontStyle": "normal",
+					"fontWeight": "600",
+					"textTransform": "none"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontStyle": "normal",
+					"fontWeight": "600"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontStyle": "italic"
+				}
+			},
+			"link": {
+				":hover": {
+					"typography": {
+					"textDecoration": "none"
+					}
+				}
+			},
+			"button": {
+				"border": {
+					"radius": "50px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--secondary)"
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--tertiary)"
+					}
+				},
+				":focus": {
+					"color": {
+						"background": "var(--wp--preset--color--primary)"
+					}
+				},
+				":active": {
+					"color": {
+						"background": "var(--wp--preset--color--primary)"
+					}
+				}
+			}
 		},
 		"spacing": {
-		  "margin": {
-			"bottom": "var(--wp--preset--spacing--50)",
-			"top": "var(--wp--preset--spacing--50)"
-		  }
-		},
-		"typography": {
-		  "fontWeight": "600"
-		}
-	  },
-	  "core/pullquote": {
-		"border": {
-		  "width": "1px 0"
-		}
-	  },
-	  "core/query-pagination": {
-		"elements": {
-		  "link": {
-			"typography": {
-			  "textDecoration": "none"
+			"blockGap": "2.5rem",
+			"padding": {
+				"bottom": "var(--wp--preset--spacing--50)",
+				"left": "var(--wp--preset--spacing--40)",
+				"right": "var(--wp--preset--spacing--40)",
+				"top": "var(--wp--preset--spacing--50)"
 			}
-		  }
 		},
 		"typography": {
-		  "fontSize": "var(--wp--preset--font-size--small)",
-		  "fontWeight": "400"
+			"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
+			"fontSize": "var(--wp--preset--font-size--normal)",
+			"lineHeight": "1.5"
 		}
-	  },
-	  "core/quote": {
-		"elements": {
-		  "cite": {
-			"typography": {
-			  "fontSize": "1.25rem"
-			}
-		  }
-		},
-		"typography": {
-		  "fontSize": "1.625rem",
-		  "lineHeight": "1.5"
-		}
-	  },
-	  "core/site-title": {
-		"elements": {
-		  "link": {
-			"typography": {
-			  "fontSize": "var(--wp--preset--font-size--normal)"
-			}
-		  }
-		},
-		"typography": {
-			"textTransform": "lowercase"
-		}
-	  }
-	},
-	"elements": {
-	  "h1": {
-		"typography": {
-		  "fontSize": "var(--wp--preset--font-size--huge)",
-		  "lineHeight": "1.1"
-		}
-	  },
-	  "h2": {
-		"typography": {
-		  "fontSize": "var(--wp--preset--font-size--xx-large)",
-		  "lineHeight": "1.2"
-		}
-	  },
-	  "h3": {
-		"typography": {
-		  "fontSize": "var(--wp--preset--font-size--x-large)",
-		  "lineHeight": "1.2"
-		}
-	  },
-	  "h4": {
-		"typography": {
-          "fontSize": "var(--wp--preset--font-size--large)",
-		  "fontWeight": "600"
-		}
-	  },
-	  "h5": {
-		"typography": {
-		  "fontStyle": "normal",
-		  "fontWeight": "600",
-		  "textTransform": "none"
-		}
-	  },
-	  "h6": {
-		"typography": {
-          "fontSize": "var(--wp--preset--font-size--normal)",
-		  "fontStyle": "normal",
-		  "fontWeight": "600"
-		}
-	  },
-	  "heading": {
-		"typography": {
-		  "fontStyle": "italic"
-		}
-	  },
-	  "link": {
-		":hover": {
-		  "typography": {
-			"textDecoration": "none"
-		  }
-		}
-	  },
-	  "button": {
-		"border": {
-		  "radius": "50px"
-		},
-		"color": {
-		  "background": "var(--wp--preset--color--secondary)"
-		},
-		"typography": {
-		  "fontSize": "var(--wp--preset--font-size--normal)"
-		},
-		":hover": {
-		  "color": {
-			"background": "var(--wp--preset--color--tertiary)"
-		  }
-		},
-		":focus": {
-		  "color": {
-			"background": "var(--wp--preset--color--primary)"
-		  }
-		},
-		":active": {
-		  "color": {
-			"background": "var(--wp--preset--color--primary)"
-		  }
-		}
-	  }
-	},
-	"spacing": {
-	  "blockGap": "2.5rem",
-	  "padding": {
-		"bottom": "var(--wp--preset--spacing--50)",
-		"left": "var(--wp--preset--spacing--40)",
-		"right": "var(--wp--preset--spacing--40)",
-		"top": "var(--wp--preset--spacing--50)"
-	  }
-	},
-	"typography": {
-	  "fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
-	  "fontSize": "var(--wp--preset--font-size--normal)",
-	  "lineHeight": "1.5"
 	}
-  },
-  "version": 2
 }

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Pilgrimage",
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -1,5 +1,6 @@
 {
-	"title": "Pilgrimage",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"settings": {
 		"color": {
 			"duotone": [
@@ -295,7 +296,5 @@
 				}
 			}
 		}
-	},
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	}
 }

--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -1,5 +1,6 @@
 {
-	"title": "Pitch",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"settings": {
 		"color": {
 			"palette": [
@@ -239,7 +240,5 @@
 			"fontSize": "var(--wp--preset--font-size--medium)",
 			"lineHeight": "1.7"
 		}
-	},
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	}
 }

--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Pitch",
 	"settings": {
 		"color": {
 			"palette": [

--- a/styles/sherbet.json
+++ b/styles/sherbet.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
-	"title": "Sherbet",
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/sherbet.json
+++ b/styles/sherbet.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Sherbet",
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/whisper.json
+++ b/styles/whisper.json
@@ -1,5 +1,6 @@
 {
-	"title": "Whisper",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"settings": {
 		"color": {
 			"palette": [
@@ -509,7 +510,5 @@
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--dm-sans)"
 		}
-	},
-	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	}
 }

--- a/styles/whisper.json
+++ b/styles/whisper.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Whisper",
 	"settings": {
 		"color": {
 			"palette": [


### PR DESCRIPTION
This PR makes the following changes to the global style JSON files:

### Move `$schema` and `version` to top

Related to #54, I think these two properties should be defined first.

### Remove `title` property

Currently, the title property is not allowed in the schema, nor is it used in the site editor.
As [Gutenberg issue](https://github.com/WordPress/gutenberg/issues/44730), it has been suggested that the title be displayed in the preview, but I think that the incorrect property should be removed at this time.

### Unified indentation

In the Marigold theme, tab indentation and space indentation were mixed, so they were unified into tab indentation.

### Remove Incorrect style property

In the Marigold theme, the following incorrect border styles were defined:

```json
"border": {
  "bottom": true
}
```

This property was removed because it doesn't accept a boolean value and doesn't appear to be applied to the style.

### Remaining problems

The code editor doesn't allow the `filter` property, but this is a problem on the JSON schema side and I would like to submit a separate PR to Gutenberg.

![filter](https://user-images.githubusercontent.com/54422211/194715076-004069e8-19a4-4545-80a8-91c9963ec09b.png)


If you have any questions about this PR, I would be happy to answer them.