### PR TITLE
Add accessibility-ready tag

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,5 +11,5 @@ Version: 1.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: twentytwentythree
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, accessibility-ready
 */


### PR DESCRIPTION
This adds the `accessibility-ready` tag, based on the accessibility check completed as part of https://github.com/WordPress/twentytwentythree/issues/218.

Closes https://github.com/WordPress/twentytwentythree/issues/218.