### PR TITLE
Pre RC1 merge changes

### DIFF
--- a/styles/marigold.json
+++ b/styles/marigold.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://schemas.wp.org/trunk/theme.json",
-  "version": 2,
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
 	"title": "Marigold",
-  "settings": {
+	"settings": {
 		"color": {
 			"palette": [
 				{


### PR DESCRIPTION
This makes an adjustment that was included when the theme was synced in RC1 in [Trac-54467](https://core.trac.wordpress.org/changeset/54467).

A few lines in the Marigold style file were indented with spaces instead of tabs.