### PR TITLE
Remove Theme Options tag

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,5 +11,5 @@ Version: 1.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: twentytwentythree
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, accessibility-ready
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, translation-ready, wide-blocks, accessibility-ready
 */


### PR DESCRIPTION
Theme Options tag is only valid when, "Has theme options (customizer)". We don't have a customizer in this theme.
https://make.wordpress.org/themes/handbook/review/required/theme-tags/