### PR TITLE
Canary: Apply single font sizes as overrides and remove font family definition on headings

### DIFF
--- a/styles/canary.json
+++ b/styles/canary.json
@@ -96,11 +96,6 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
-			"core/heading": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)"
-				}
-			},
 			"core/image": {
 				"border": {
 					"radius": "100px 0 0 0"

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -61,8 +61,7 @@
 				},
 				{
 					"size": "2.25rem",
-					"slug": "x-large",
-					"fluid": false
+					"slug": "x-large"
 				},
 				{
 					"size": "10rem",

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -50,6 +50,23 @@
 				{
 					"size": "0.75rem",
 					"slug": "small"
+				},
+				{
+					"size": "1.125rem",
+					"slug": "medium"
+				},
+				{
+					"size": "1.75rem",
+					"slug": "large"
+				},
+				{
+					"size": "2.25rem",
+					"slug": "x-large",
+					"fluid": false
+				},
+				{
+					"size": "10rem",
+					"slug": "xx-large"
 				}
 			]
 		}

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -50,22 +50,6 @@
 				{
 					"size": "0.75rem",
 					"slug": "small"
-				},
-				{
-					"size": "0.75rem",
-					"slug": "medium"
-				},
-				{
-					"size": "0.75rem",
-					"slug": "large"
-				},
-				{
-					"size": "0.75rem",
-					"slug": "x-large"
-				},
-				{
-					"size": "0.75rem",
-					"slug": "xx-large"
 				}
 			]
 		}
@@ -87,6 +71,11 @@
 				}
 			},
 			"core/comment-reply-link": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/comments-title":{
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
@@ -121,6 +110,11 @@
 							}
 						}
 					}
+				}
+			},
+			"core/post-excerpt": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/post-featured-image": {
@@ -162,7 +156,8 @@
 			"core/site-title": {
 				"typography": {
 					"fontWeight": "700",
-					"textTransform": "lowercase"
+					"textTransform": "lowercase",
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			}
 		},
@@ -210,22 +205,22 @@
 			},
 			"h1": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"heading": {
@@ -240,7 +235,8 @@
 			}
 		},
 		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)"
+			"fontFamily": "var(--wp--preset--font-family--ibm-plex-mono)",
+			"fontSize": "var(--wp--preset--font-size--small)"
 		}
 	}
 }


### PR DESCRIPTION
This changes the way the single font size preset is applied in Canary, as it seems to be causing issues with how typography is used in Global Styles.

Instead of overwriting each font size preset with the same value, this overrides each font size setting to the same preset (`small`).

This also removes the font family setting for `core/heading`, as this doesn't seem to be required anymore and it makes managing the font families from Global Styles less confusing.

Fixes https://github.com/WordPress/twentytwentythree/issues/278.