### PR TITLE
Add name for xx-large font size

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -282,7 +282,8 @@
 					"fluid": {
 						"min": "4rem",
 						"max": "20rem"
-					}
+					},
+					"name": "2X Large"
 				}
 			]
 		},


### PR DESCRIPTION
Adds a `name` to the `xx-large` font size, so the UI does not show "undefined."

For #280.

<img width="517" alt="CleanShot 2022-10-13 at 16 03 50@2x" src="https://user-images.githubusercontent.com/1813435/195698793-6e90691a-1de2-4f9b-9f94-92077ec6dae8.png">
