### PR TITLE
Reduce max size for XXL font size preset

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -264,25 +264,25 @@
 					"slug": "medium"
 				},
 				{
-					"size": "1.75rem",
-					"slug": "large",
 					"fluid": {
 						"min": "1.75rem",
 						"max": "1.875rem"
-					}
+					},
+					"size": "1.75rem",
+					"slug": "large"
 				},
 				{
+					"fluid": false,
 					"size": "2.25rem",
-					"slug": "x-large",
-					"fluid": false
+					"slug": "x-large"
 				},
 				{
-					"size": "10rem",
-					"slug": "xx-large",
 					"fluid": {
 						"min": "4rem",
-						"max": "20rem"
-					}
+						"max": "10rem"
+					},
+					"size": "10rem",
+					"slug": "xx-large"
 				}
 			]
 		},


### PR DESCRIPTION
This reduces the max size for the XXL font size preset to `10rem` from `20rem`. It also re-orders the font size properties so that they are all in the same order, with the `fluid` key at the beginning of each object.

Closes https://github.com/WordPress/twentytwentythree/issues/282.