### PR TITLE
Add subject tags to style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,5 +11,5 @@ Version: 1.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: twentytwentythree
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, accessibility-ready
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, accessibility-ready, blog, portfolio, news
 */


### PR DESCRIPTION
Adds the blog, portfolio, and news subject tags.

Closes https://github.com/WordPress/twentytwentythree/issues/276.