### PR TITLE
Rename Comments template part

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -718,7 +718,7 @@
 		{
 			"area": "uncategorized",
 			"name": "comments",
-			"title": "Comments"
+			"title": "Comments Template Part"
 		},
 		{
 			"area": "uncategorized",


### PR DESCRIPTION
This renames the Comments template part to 'Comments Template Part', to reduce confusion with the 'Comments' block when viewing both in the inserter.

<img width="376" alt="image" src="https://user-images.githubusercontent.com/1645628/197159171-5a6d7cea-fb75-4c41-a0cd-de80e5bfb35a.png">

Addresses the discussion here: https://github.com/WordPress/gutenberg/issues/45084#issuecomment-1284452830