### PR TITLE
Set text colour for file block button

### DIFF
--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -95,17 +95,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/file": {
-				"elements": {
-					"button": {
-						":visited": {
-							"color": {
-								"text": "var(--wp--preset--color--base)"
-							}
-						}
-					}
-				}
-			},
 			"core/comment-reply-link": {
 				"elements": {
 					"link": {
@@ -275,6 +264,11 @@
 						"background": "var(--wp--preset--color--primary)",
 						"gradient": "none",
 						"text": "var(--wp--preset--color--secondary)"
+					}
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
 					}
 				}
 			},

--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -95,6 +95,15 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/file": {
+				"elements": {
+					"button": {
+						"color": {
+							"text": "var(--wp--preset--color--base)"
+						}
+					}
+				}
+			},
 			"core/comment-reply-link": {
 				"elements": {
 					"link": {

--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -98,8 +98,10 @@
 			"core/file": {
 				"elements": {
 					"button": {
-						"color": {
-							"text": "var(--wp--preset--color--base)"
+						":visited": {
+							"color": {
+								"text": "var(--wp--preset--color--base)"
+							}
 						}
 					}
 				}

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -189,6 +189,11 @@
 						"width": "2px"
 					}
 				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
 				"border": {
 					"radius": "5px",
 					"color": "var(--wp--preset--color--contrast)",

--- a/styles/electric.json
+++ b/styles/electric.json
@@ -38,8 +38,10 @@
 			"core/file": {
 				"elements": {
 					"button": {
-						"color": {
-							"text": "var(--wp--preset--color--base)"
+						":visited": {
+							"color": {
+								"text": "var(--wp--preset--color--base)"
+							}
 						}
 					}
 				}

--- a/styles/electric.json
+++ b/styles/electric.json
@@ -34,19 +34,6 @@
 		}
 	},
 	"styles": {
-		"blocks": {
-			"core/file": {
-				"elements": {
-					"button": {
-						":visited": {
-							"color": {
-								"text": "var(--wp--preset--color--base)"
-							}
-						}
-					}
-				}
-			}
-		},
 		"elements": {
 			"button": {
 				"border": {
@@ -85,6 +72,11 @@
 					"color": {
 						"background": "var(--wp--preset--color--base)",
 						"text": "var(--wp--preset--color--contrast)"
+					}
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
 					}
 				}
 			},

--- a/styles/electric.json
+++ b/styles/electric.json
@@ -34,6 +34,17 @@
 		}
 	},
 	"styles": {
+		"blocks": {
+			"core/file": {
+				"elements": {
+					"button": {
+						"color": {
+							"text": "var(--wp--preset--color--base)"
+						}
+					}
+				}
+			}
+		},
 		"elements": {
 			"button": {
 				"border": {

--- a/styles/grapes.json
+++ b/styles/grapes.json
@@ -38,8 +38,10 @@
 			"core/file": {
 				"elements": {
 					"button": {
-						"color": {
-							"text": "var(--wp--preset--color--base)"
+						":visited": {
+							"color": {
+								"text": "var(--wp--preset--color--base)"
+							}
 						}
 					}
 				}

--- a/styles/grapes.json
+++ b/styles/grapes.json
@@ -35,17 +35,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/file": {
-				"elements": {
-					"button": {
-						":visited": {
-							"color": {
-								"text": "var(--wp--preset--color--base)"
-							}
-						}
-					}
-				}
-			},
 			"core/post-comments": {
 				"elements": {
 					"link": {
@@ -83,6 +72,11 @@
 				"color": {
 					"background": "var(--wp--preset--color--primary)",
 					"text": "var(--wp--preset--color--base)"
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
+					}
 				}
 			},
 			"heading": {

--- a/styles/grapes.json
+++ b/styles/grapes.json
@@ -35,6 +35,15 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/file": {
+				"elements": {
+					"button": {
+						"color": {
+							"text": "var(--wp--preset--color--base)"
+						}
+					}
+				}
+			},
 			"core/post-comments": {
 				"elements": {
 					"link": {

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -125,8 +125,10 @@
 			"core/file": {
 				"elements": {
 					"button": {
-						"color": {
-							"text": "var(--wp--preset--color--base)"
+						":visited": {
+							"color": {
+								"text": "var(--wp--preset--color--base)"
+							}
 						}
 					}
 				}

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -122,17 +122,6 @@
 					}
 				}
 			},
-			"core/file": {
-				"elements": {
-					"button": {
-						":visited": {
-							"color": {
-								"text": "var(--wp--preset--color--base)"
-							}
-						}
-					}
-				}
-			},
 			"core/image": {
 				"filter": {
 					"duotone": "var(--wp--preset--duotone--default-filter)"
@@ -259,6 +248,11 @@
 				":hover": {
 					"color": {
 						"gradient": "var(--wp--preset--gradient--secondary-primary)"
+					}
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
 					}
 				},
 				"border": {

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -122,6 +122,15 @@
 					}
 				}
 			},
+			"core/file": {
+				"elements": {
+					"button": {
+						"color": {
+							"text": "var(--wp--preset--color--base)"
+						}
+					}
+				}
+			},
 			"core/image": {
 				"filter": {
 					"duotone": "var(--wp--preset--duotone--default-filter)"

--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -130,17 +130,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/file": {
-				"elements": {
-					"button": {
-						":visited": {
-							"color": {
-								"text": "var(--wp--preset--color--base)"
-							}
-						}
-					}
-				}
-			},
 			"core/separator": {
 				"border": {
 					"color":"var(--wp--preset--color--tertiary)",
@@ -206,6 +195,11 @@
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
 						"text": "var(--wp--preset--color--tertiary)"
+					}
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
 					}
 				}
 			},

--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -130,6 +130,15 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/file": {
+				"elements": {
+					"button": {
+						"color": {
+							"text": "var(--wp--preset--color--base)"
+						}
+					}
+				}
+			},
 			"core/separator": {
 				"border": {
 					"color":"var(--wp--preset--color--tertiary)",

--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -133,8 +133,10 @@
 			"core/file": {
 				"elements": {
 					"button": {
-						"color": {
-							"text": "var(--wp--preset--color--base)"
+						":visited": {
+							"color": {
+								"text": "var(--wp--preset--color--base)"
+							}
 						}
 					}
 				}

--- a/styles/whisper.json
+++ b/styles/whisper.json
@@ -86,8 +86,10 @@
 			"core/file": {
 				"elements": {
 					"button": {
-						"color": {
-							"text": "var(--wp--preset--color--primary)"
+						":visited": {
+							"color": {
+								"text": "var(--wp--preset--color--primary)"
+							}
 						}
 					}
 				}

--- a/styles/whisper.json
+++ b/styles/whisper.json
@@ -83,17 +83,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/file": {
-				"elements": {
-					"button": {
-						":visited": {
-							"color": {
-								"text": "var(--wp--preset--color--primary)"
-							}
-						}
-					}
-				}
-			},
 			"core/navigation": {
 				"color": {
 					"text": "var(--wp--preset--color--contrast)"
@@ -431,6 +420,11 @@
 						"padding": {
 							"bottom": "min(calc(1rem + 2px), 3vw) !important"
 						}
+					}
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--primary)"
 					}
 				}
 			},

--- a/styles/whisper.json
+++ b/styles/whisper.json
@@ -83,6 +83,15 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/file": {
+				"elements": {
+					"button": {
+						"color": {
+							"text": "var(--wp--preset--color--primary)"
+						}
+					}
+				}
+			},
 			"core/navigation": {
 				"color": {
 					"text": "var(--wp--preset--color--contrast)"

--- a/theme.json
+++ b/theme.json
@@ -290,17 +290,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/file": {
-				"elements": {
-					"button": {
-						":visited": {
-							"color": {
-								"text": "var(--wp--preset--color--contrast)"
-							}
-						}
-					}
-				}
-			},
 			"core/navigation": {
 				"elements": {
 					"link": {
@@ -629,6 +618,11 @@
 					"color": {
 						"background": "var(--wp--preset--color--secondary)",
 						"text": "var(--wp--preset--color--base)"
+					}
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--contrast)"
 					}
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -293,8 +293,10 @@
 			"core/file": {
 				"elements": {
 					"button": {
-						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+						":visited": {
+							"color": {
+								"text": "var(--wp--preset--color--contrast)"
+							}
 						}
 					}
 				}

--- a/theme.json
+++ b/theme.json
@@ -290,6 +290,15 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/file": {
+				"elements": {
+					"button": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
+					}
+				}
+			},
 			"core/navigation": {
 				"elements": {
 					"link": {


### PR DESCRIPTION
This sets a text colour for the file block button, which overrides a default `:visited` text colour set by [Core here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/file/style.scss#L34).

Fixes https://github.com/WordPress/twentytwentythree/issues/288.