### PR TITLE
Remove 'years' from theme descrption

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-Twenty Twenty-Three is designed to take advantage of the new design tools introduced in WordPress 6.1. With a clean, blank base as a starting point, this year's default theme includes ten diverse style variations created by members of the WordPress community.
+Twenty Twenty-Three is designed to take advantage of the new design tools introduced in WordPress 6.1. With a clean, blank base as a starting point, this default theme includes ten diverse style variations created by members of the WordPress community.
 
 Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ Theme Name: Twenty Twenty-Three
 Theme URI: https://wordpress.org/themes/twentytwentythree
 Author: the WordPress team
 Author URI: https://wordpress.org
-Description: Twenty Twenty-Three is designed to take advantage of the new design tools introduced in WordPress 6.1. With a clean, blank base as a starting point, this year's default theme includes ten diverse style variations created by members of the WordPress community. Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
+Description: Twenty Twenty-Three is designed to take advantage of the new design tools introduced in WordPress 6.1. With a clean, blank base as a starting point, this default theme includes ten diverse style variations created by members of the WordPress community. Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 Requires at least: 6.1
 Tested up to: 6.1
 Requires PHP: 5.6


### PR DESCRIPTION
Quick PR to update theme description in line with discussion on [Slack](https://wordpress.slack.com/archives/C02RP4VMP/p1666603716085579?thread_ts=1666350157.675029&cid=C02RP4VMP).