### PR TITLE
Try fixing combined hover and visited button states

### DIFF
--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -245,6 +245,11 @@
 					"gradient": "var(--wp--preset--gradient--tertiary-primary)",
 					"text": "var(--wp--preset--color--base)"
 				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
@@ -264,11 +269,6 @@
 						"background": "var(--wp--preset--color--primary)",
 						"gradient": "none",
 						"text": "var(--wp--preset--color--secondary)"
-					}
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--base)"
 					}
 				}
 			},

--- a/styles/aubergine.json
+++ b/styles/aubergine.json
@@ -254,7 +254,7 @@
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
 						"gradient": "none",
-						"text": "var(--wp--preset--color--secondary)"
+						"text": "var(--wp--preset--color--secondary) !important"
 					}
 				},
 				":focus": {

--- a/styles/canary.json
+++ b/styles/canary.json
@@ -170,7 +170,7 @@
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--base)",
-						"text": "var(--wp--preset--color--contrast)"
+						"text": "var(--wp--preset--color--contrast) !important"
 					},
 					"border": {
 						"color": "var(--wp--preset--color--contrast)",

--- a/styles/electric.json
+++ b/styles/electric.json
@@ -53,6 +53,11 @@
 						"left": "1.333em"
 					}
 				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
 				":active": {
 					"typography": {
 						"textDecoration": "underline dotted"
@@ -72,11 +77,6 @@
 					"color": {
 						"background": "var(--wp--preset--color--base)",
 						"text": "var(--wp--preset--color--contrast)"
-					}
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--base)"
 					}
 				}
 			},

--- a/styles/electric.json
+++ b/styles/electric.json
@@ -76,7 +76,7 @@
 					},
 					"color": {
 						"background": "var(--wp--preset--color--base)",
-						"text": "var(--wp--preset--color--contrast)"
+						"text": "var(--wp--preset--color--contrast) !important"
 					}
 				}
 			},

--- a/styles/pilgrimage.json
+++ b/styles/pilgrimage.json
@@ -234,6 +234,18 @@
 		},
 		"elements": {
 			"button": {
+				"border": {
+					"radius": "5px"
+				},
+				"color": {
+					"gradient": "var(--wp--preset--gradient--primary-secondary)",
+					"text": "var(--wp--preset--color--base)"
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
 				":active": {
 					"color": {
 						"background": "var(--wp--preset--color--secondary)",
@@ -249,18 +261,6 @@
 					"color": {
 						"gradient": "var(--wp--preset--gradient--secondary-primary)"
 					}
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--base)"
-					}
-				},
-				"border": {
-					"radius": "5px"
-				},
-				"color": {
-					"gradient": "var(--wp--preset--gradient--primary-secondary)",
-					"text": "var(--wp--preset--color--base)"
 				}
 			},
 			"h1": {

--- a/styles/pitch.json
+++ b/styles/pitch.json
@@ -176,7 +176,7 @@
 					},
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
-						"text": "var(--wp--preset--color--tertiary)"
+						"text": "var(--wp--preset--color--tertiary) !important"
 					}
 				},
 				":focus": {

--- a/styles/whisper.json
+++ b/styles/whisper.json
@@ -376,6 +376,11 @@
 					"letterSpacing": "1px",
 					"textTransform": "uppercase"
 				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--primary)"
+					}
+				},
 				":hover": {
 					"border": {
 						"color": "var(--wp--preset--color--secondary)",
@@ -420,11 +425,6 @@
 						"padding": {
 							"bottom": "min(calc(1rem + 2px), 3vw) !important"
 						}
-					}
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--primary)"
 					}
 				}
 			},

--- a/styles/whisper.json
+++ b/styles/whisper.json
@@ -388,7 +388,7 @@
 					},
 					"color": {
 						"background": "var(--wp--preset--color--tertiary)",
-						"text": "var(--wp--preset--color--secondary)"
+						"text": "var(--wp--preset--color--secondary) !important"
 					},
 					"spacing": {
 						"padding": {

--- a/theme.json
+++ b/theme.json
@@ -610,7 +610,7 @@
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
-						"text": "var(--wp--preset--color--base)"
+						"text": "var(--wp--preset--color--base) !important"
 					}
 				},
 				":focus": {

--- a/theme.json
+++ b/theme.json
@@ -602,6 +602,11 @@
 					"background": "var(--wp--preset--color--primary)",
 					"text": "var(--wp--preset--color--contrast)"
 				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--contrast)"
+					}
+				},
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--contrast)",
@@ -618,11 +623,6 @@
 					"color": {
 						"background": "var(--wp--preset--color--secondary)",
 						"text": "var(--wp--preset--color--base)"
-					}
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--contrast)"
 					}
 				}
 			},


### PR DESCRIPTION
When both the visited and hover states are active on a button, the visited text colour overrides the hover text colour, which means the two colours are not contrasting in some cases.

This attempts to fix this by adding an !important tag to the hover state text colour. I don't think this is ideal, but re-ordering the properties didn't seem to make a difference here.

Addresses this comment: https://github.com/WordPress/twentytwentythree/issues/288#issuecomment-1293504927